### PR TITLE
Fix workflow build failure: Add shell declarations for Bash syntax on Windows runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
           fi
 
       - name: Create Assembly Directory Structure
+        shell: bash
         run: |
           mkdir -p DedicatedServerMod/ScheduleOneAssemblies/Managed
           mkdir -p DedicatedServerMod/ScheduleOneAssemblies/MelonLoader
@@ -68,6 +69,7 @@ jobs:
         if: steps.cache-assemblies.outputs.cache-hit != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
 
       - name: Copy Game Assemblies
+        shell: bash
         run: |
           if [ -d "game-assemblies/Managed" ]; then
             cp -r game-assemblies/Managed/* DedicatedServerMod/ScheduleOneAssemblies/Managed/ || echo "Failed to copy Mono assemblies"
@@ -81,6 +83,7 @@ jobs:
         if: steps.cache-assemblies.outputs.cache-hit != 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
 
       - name: Verify Assemblies
+        shell: bash
         run: |
           if [ -f "DedicatedServerMod/ScheduleOneAssemblies/Managed/Assembly-CSharp.dll" ]; then
             echo "✓ Found Assembly-CSharp.dll"
@@ -90,6 +93,7 @@ jobs:
           fi
 
       - name: Create CI Build Properties
+        shell: bash
         run: |
           cat > ci.build.props << 'EOF'
           <Project>


### PR DESCRIPTION
## Description
GitHub Actions workflow failed on Windows runner because steps using Bash syntax (if [ -f ... ], cp -r, heredoc) defaulted to PowerShell without explicit shell declaration.


## Changes Made
Added shell: bash to 4 steps in .github/workflows/build.yml:
-    Create Assembly Directory Structure (mkdir -p)
-    Copy Game Assemblies (cp -r, conditional tests)
-    Verify Assemblies (file existence check) - failing step
-    Create CI Build Properties (heredoc syntax)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- **Fixed GitHub Actions workflow build failure on Windows runners** by explicitly declaring `shell: bash` for steps using Bash syntax that would otherwise execute under PowerShell by default
- **Added `shell: bash` declaration to four workflow steps**:
  - Create Assembly Directory Structure (mkdir -p)
  - Copy Game Assemblies (cp -r with conditional tests)
  - Verify Assemblies (file existence check)
  - Create CI Build Properties (heredoc)
- **Enhanced step messaging and validation**: Added echo outputs for successful assembly copies and assembly verification with exit code failure if Assembly-CSharp.dll is missing
- **Implemented heredoc syntax for CI build properties file** creation under explicit Bash context

---

## Contribution Summary

| Author | Lines Added | Lines Removed |
|--------|------------|---------------|
| copilot-swe-agent[bot] (co-authored with galadril) | 4 | 0 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->