### PR TITLE
docs(Docs): Update build instructions for MelonLoader requirements

### DIFF
--- a/BUILD_SETUP.md
+++ b/BUILD_SETUP.md
@@ -65,6 +65,8 @@ dotnet build -c Mono_Server
 dotnet build
 ```
 
+*You must launch the game with MelonLoader at least once before building this project so MelonLoader can generate the MelonLoader/Il2CppAssemblies directory required by the Il2cpp_Client and Il2cpp_Server configurations. This is not Linux-specific: the same generated assemblies are required on Windows as well. MelonLoader's IL2CPP toolchain also depends on the .NET 6 runtime being available in the environment where the game is launched, whether that is a normal Windows install or a Proton/Wine prefix on Linux. The project's netstandard2.1 target remains valid for local builds; the critical requirement is that the game-side IL2CPP assemblies have been generated before you compile against them. .NET 6 can be installed inside of your prefix if on Linux by downloading the .exe*
+
 ## How It Works
 
 ### Assembly Publicization


### PR DESCRIPTION
## Description
Added instructions for launching the game with MelonLoader before building the project, emphasizing the need for generated assemblies and .NET 6 runtime availability.

## Related Issues
N/A

## Changes Made
N/A

## Testing Performed
N/A

## Screenshots
N/A

## Checklist
<!-- Please check all that apply -->
- [x] Code follows [CODING_STANDARDS.md](CODING_STANDARDS.md)
- [x] XML documentation added for public APIs
- [x] No compiler warnings with both Mono_Server & Mono_Client builds
- [x] No breaking changes (or clearly documented below)
- [x] Updated relevant documentation
- [x] Commit messages follow conventional commit format

## Breaking Changes
<!-- If there are breaking changes, describe them here and provide migration guidance -->

## Additional Notes
<!-- Any other information that would be helpful for reviewers -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Release Notes

- Updated build setup documentation to clarify MelonLoader requirements for building the project
- Added prerequisite note requiring developers to launch the game with MelonLoader at least once before building to generate required IL2CPP assemblies
- Documented that MelonLoader's IL2CPP toolchain requires .NET 6 runtime availability in the build environment
- Clarified that this requirement applies to both Linux and Windows build configurations

## Changes by Author

| Author | Lines Added | Lines Removed |
|--------|-------------|---------------|
| Zack Eckersley Pallett | 2 | 0 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->