### PR TITLE
fix(client): stabilize il2cpp reconnect loading

### DIFF
--- a/Client/Core/ClientBootstrap.cs
+++ b/Client/Core/ClientBootstrap.cs
@@ -81,6 +81,11 @@ namespace DedicatedServerMod.Client.Core
         /// The loopback handler for ghost player management.
         /// </summary>
         private ClientLoopbackHandler _loopbackHandler;
+
+        /// <summary>
+        /// Optional real-game reconnect diagnostic runner enabled by command-line flag.
+        /// </summary>
+        private ClientReconnectTestRunner _reconnectTestRunner;
         
 
         /// <summary>
@@ -300,6 +305,9 @@ namespace DedicatedServerMod.Client.Core
             // Initialize UI manager (depends on connection manager)
             _uiManager = new ClientUIManager(_connectionManager);
             _uiManager.Initialize();
+
+            _reconnectTestRunner = new ClientReconnectTestRunner(_connectionManager);
+            _reconnectTestRunner.Initialize();
         }
 
         #endregion
@@ -412,6 +420,15 @@ namespace DedicatedServerMod.Client.Core
             catch (Exception ex)
             {
                 _logger?.Warning($"Error notifying client mods of shutdown: {ex.Message}");
+            }
+
+            try
+            {
+                _reconnectTestRunner?.Shutdown();
+            }
+            catch (Exception ex)
+            {
+                _logger?.Warning($"Error shutting down reconnect test runner: {ex.Message}");
             }
 
             try

--- a/Client/Core/ClientReconnectTestRunner.cs
+++ b/Client/Core/ClientReconnectTestRunner.cs
@@ -1,0 +1,310 @@
+#if IL2CPP
+using Il2CppScheduleOne.DevUtilities;
+using Il2CppScheduleOne.Persistence;
+#else
+using ScheduleOne.DevUtilities;
+using ScheduleOne.Persistence;
+#endif
+using System;
+using System.Collections;
+using System.Globalization;
+using System.IO;
+using DedicatedServerMod.Client.Managers;
+using DedicatedServerMod.Utils;
+using MelonLoader;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace DedicatedServerMod.Client.Core
+{
+    /// <summary>
+    /// Opt-in real-game reconnect diagnostic runner for IL2CPP loading regressions.
+    /// </summary>
+    internal sealed class ClientReconnectTestRunner
+    {
+        private const string TestFlag = "--s1ds-reconnect-test";
+        private const string HostFlag = "--s1ds-reconnect-test-host";
+        private const string PortFlag = "--s1ds-reconnect-test-port";
+        private const string CyclesFlag = "--s1ds-reconnect-test-cycles";
+        private const string DwellFlag = "--s1ds-reconnect-test-dwell-seconds";
+        private const string StartDelayFlag = "--s1ds-reconnect-test-start-delay-seconds";
+        private const string StartMarkerFlag = "--s1ds-reconnect-test-start-marker";
+        private const string JoinTimeoutFlag = "--s1ds-reconnect-test-join-timeout-seconds";
+        private const string MenuTimeoutFlag = "--s1ds-reconnect-test-menu-timeout-seconds";
+        private const string QuitFlag = "--s1ds-reconnect-test-quit";
+
+        private readonly ClientConnectionManager _connectionManager;
+        private ReconnectTestOptions _options;
+        private bool _enabled;
+        private bool _started;
+        private bool _failed;
+        private bool _connectionEventReceived;
+        private int _completedCycles;
+
+        internal ClientReconnectTestRunner(ClientConnectionManager connectionManager)
+        {
+            _connectionManager = connectionManager;
+        }
+
+        internal void Initialize()
+        {
+            _options = ReconnectTestOptions.Parse(Environment.GetCommandLineArgs());
+            _enabled = _options.Enabled;
+            if (!_enabled)
+            {
+                return;
+            }
+
+            _connectionManager.DedicatedServerConnected += OnDedicatedServerConnected;
+            MelonCoroutines.Start(RunTest());
+        }
+
+        internal void Shutdown()
+        {
+            if (_enabled)
+            {
+                _connectionManager.DedicatedServerConnected -= OnDedicatedServerConnected;
+            }
+        }
+
+        private IEnumerator RunTest()
+        {
+            if (_started)
+            {
+                yield break;
+            }
+
+            _started = true;
+            Log($"START cycles={_options.Cycles} dwellSeconds={_options.DwellSeconds:F1} startDelaySeconds={_options.StartDelaySeconds:F1} host={_options.Host} port={_options.Port}");
+
+            if (!string.IsNullOrWhiteSpace(_options.StartMarkerPath))
+            {
+                yield return WaitForStartMarker();
+                if (_failed)
+                {
+                    yield break;
+                }
+            }
+            else if (_options.StartDelaySeconds > 0f)
+            {
+                yield return new WaitForSecondsRealtime(_options.StartDelaySeconds);
+            }
+
+            yield return WaitForMenu(_options.MenuTimeoutSeconds, "initial-menu");
+            if (_failed)
+            {
+                yield break;
+            }
+
+            for (int cycle = 1; cycle <= _options.Cycles; cycle++)
+            {
+                _connectionEventReceived = false;
+                _connectionManager.SetTargetServer(_options.Host, _options.Port);
+
+                Log($"CYCLE {cycle}/{_options.Cycles} JOIN_START");
+                _connectionManager.StartDedicatedConnection();
+
+                float joinStart = Time.realtimeSinceStartup;
+                yield return new WaitUntil((Func<bool>)(() =>
+                    _connectionEventReceived ||
+                    _connectionManager.IsConnectedToDedicatedServer ||
+                    !string.IsNullOrWhiteSpace(_connectionManager.LastConnectionError) ||
+                    Time.realtimeSinceStartup - joinStart > _options.JoinTimeoutSeconds));
+
+                if (!_connectionManager.IsConnectedToDedicatedServer)
+                {
+                    Fail($"cycle {cycle} failed to connect within {_options.JoinTimeoutSeconds:F1}s. LastError='{_connectionManager.LastConnectionError ?? string.Empty}'");
+                    yield break;
+                }
+
+                Log($"CYCLE {cycle}/{_options.Cycles} JOINED");
+                yield return new WaitForSecondsRealtime(_options.DwellSeconds);
+
+                if (!_connectionManager.IsConnectedToDedicatedServer)
+                {
+                    Fail($"cycle {cycle} disconnected before dwell completed. LastError='{_connectionManager.LastConnectionError ?? string.Empty}'");
+                    yield break;
+                }
+
+                Log($"CYCLE {cycle}/{_options.Cycles} DWELL_OK");
+                _completedCycles = cycle;
+
+                if (cycle == _options.Cycles)
+                {
+                    break;
+                }
+
+                Log($"CYCLE {cycle}/{_options.Cycles} DISCONNECT_START");
+                _connectionManager.DisconnectFromDedicatedServer();
+                yield return WaitForMenu(_options.MenuTimeoutSeconds, $"cycle-{cycle}-menu");
+                if (_failed)
+                {
+                    yield break;
+                }
+
+                Log($"CYCLE {cycle}/{_options.Cycles} DISCONNECTED");
+            }
+
+            Log($"PASS completedCycles={_completedCycles}");
+            QuitIfRequested(exitCode: 0);
+        }
+
+        private IEnumerator WaitForStartMarker()
+        {
+            Log($"WAIT_START_MARKER path={_options.StartMarkerPath} timeoutSeconds={_options.StartDelaySeconds:F1}");
+            float waitStart = Time.realtimeSinceStartup;
+            yield return new WaitUntil((Func<bool>)(() =>
+                File.Exists(_options.StartMarkerPath) ||
+                Time.realtimeSinceStartup - waitStart > _options.StartDelaySeconds));
+
+            if (!File.Exists(_options.StartMarkerPath))
+            {
+                Fail($"timed out waiting for start marker '{_options.StartMarkerPath}'");
+            }
+            else
+            {
+                Log("START_MARKER_FOUND");
+            }
+        }
+
+        private IEnumerator WaitForMenu(float timeoutSeconds, string phase)
+        {
+            float waitStart = Time.realtimeSinceStartup;
+            yield return new WaitUntil((Func<bool>)(() =>
+                (SceneManager.GetActiveScene().name == "Menu" &&
+                 !_connectionManager.IsConnecting &&
+                 !_connectionManager.IsConnectedToDedicatedServer &&
+                 !_connectionManager.IsReturningToMenu) ||
+                Time.realtimeSinceStartup - waitStart > timeoutSeconds));
+
+            if (SceneManager.GetActiveScene().name != "Menu" ||
+                _connectionManager.IsConnecting ||
+                _connectionManager.IsConnectedToDedicatedServer ||
+                _connectionManager.IsReturningToMenu)
+            {
+                Fail($"timed out waiting for menu during {phase}");
+            }
+        }
+
+        private void OnDedicatedServerConnected(string host, int port)
+        {
+            _connectionEventReceived = true;
+        }
+
+        private static void Log(string message)
+        {
+            DebugLog.Info($"[RECONNECT_TEST] {message}");
+        }
+
+        private void Fail(string message)
+        {
+            _failed = true;
+            DebugLog.Error($"[RECONNECT_TEST] FAIL {message}");
+            QuitIfRequested(exitCode: 2);
+        }
+
+        private void QuitIfRequested(int exitCode)
+        {
+            if (!_options.QuitOnComplete)
+            {
+                return;
+            }
+
+            try
+            {
+                Application.Quit(exitCode);
+            }
+            catch
+            {
+                Application.Quit();
+            }
+        }
+
+        private sealed class ReconnectTestOptions
+        {
+            public bool Enabled { get; private set; }
+            public string Host { get; private set; } = "127.0.0.1";
+            public int Port { get; private set; } = 38465;
+            public int Cycles { get; private set; } = 4;
+            public float DwellSeconds { get; private set; } = 30f;
+            public float StartDelaySeconds { get; private set; } = 30f;
+            public string StartMarkerPath { get; private set; }
+            public float JoinTimeoutSeconds { get; private set; } = 120f;
+            public float MenuTimeoutSeconds { get; private set; } = 45f;
+            public bool QuitOnComplete { get; private set; } = true;
+
+            public static ReconnectTestOptions Parse(string[] args)
+            {
+                var options = new ReconnectTestOptions();
+                if (args == null)
+                {
+                    return options;
+                }
+
+                for (int i = 0; i < args.Length; i++)
+                {
+                    string arg = args[i];
+                    if (string.Equals(arg, TestFlag, StringComparison.Ordinal))
+                    {
+                        options.Enabled = true;
+                    }
+                    else if (string.Equals(arg, HostFlag, StringComparison.Ordinal) && TryReadNext(args, i, out string host))
+                    {
+                        options.Host = host;
+                    }
+                    else if (string.Equals(arg, PortFlag, StringComparison.Ordinal) && TryReadNext(args, i, out string portText) && int.TryParse(portText, out int port))
+                    {
+                        options.Port = port;
+                    }
+                    else if (string.Equals(arg, CyclesFlag, StringComparison.Ordinal) && TryReadNext(args, i, out string cyclesText) && int.TryParse(cyclesText, out int cycles))
+                    {
+                        options.Cycles = Mathf.Clamp(cycles, 1, 10);
+                    }
+                    else if (string.Equals(arg, DwellFlag, StringComparison.Ordinal) && TryReadNext(args, i, out string dwellText) && TryParseFloat(dwellText, out float dwellSeconds))
+                    {
+                        options.DwellSeconds = Mathf.Clamp(dwellSeconds, 1f, 300f);
+                    }
+                    else if (string.Equals(arg, StartDelayFlag, StringComparison.Ordinal) && TryReadNext(args, i, out string startDelayText) && TryParseFloat(startDelayText, out float startDelaySeconds))
+                    {
+                        options.StartDelaySeconds = Mathf.Clamp(startDelaySeconds, 0f, 300f);
+                    }
+                    else if (string.Equals(arg, StartMarkerFlag, StringComparison.Ordinal) && TryReadNext(args, i, out string startMarkerPath))
+                    {
+                        options.StartMarkerPath = startMarkerPath;
+                    }
+                    else if (string.Equals(arg, JoinTimeoutFlag, StringComparison.Ordinal) && TryReadNext(args, i, out string joinTimeoutText) && TryParseFloat(joinTimeoutText, out float joinTimeoutSeconds))
+                    {
+                        options.JoinTimeoutSeconds = Mathf.Clamp(joinTimeoutSeconds, 10f, 600f);
+                    }
+                    else if (string.Equals(arg, MenuTimeoutFlag, StringComparison.Ordinal) && TryReadNext(args, i, out string menuTimeoutText) && TryParseFloat(menuTimeoutText, out float menuTimeoutSeconds))
+                    {
+                        options.MenuTimeoutSeconds = Mathf.Clamp(menuTimeoutSeconds, 10f, 300f);
+                    }
+                    else if (string.Equals(arg, QuitFlag, StringComparison.Ordinal))
+                    {
+                        options.QuitOnComplete = true;
+                    }
+                }
+
+                return options;
+            }
+
+            private static bool TryParseFloat(string value, out float result)
+            {
+                return float.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out result);
+            }
+
+            private static bool TryReadNext(string[] args, int index, out string value)
+            {
+                value = null;
+                if (index + 1 >= args.Length)
+                {
+                    return false;
+                }
+
+                value = args[index + 1];
+                return !string.IsNullOrWhiteSpace(value);
+            }
+        }
+    }
+}

--- a/Client/Core/ClientReconnectTestRunner.cs
+++ b/Client/Core/ClientReconnectTestRunner.cs
@@ -22,16 +22,16 @@ namespace DedicatedServerMod.Client.Core
     /// </summary>
     internal sealed class ClientReconnectTestRunner
     {
-        private const string TestFlag = "--s1ds-reconnect-test";
-        private const string HostFlag = "--s1ds-reconnect-test-host";
-        private const string PortFlag = "--s1ds-reconnect-test-port";
-        private const string CyclesFlag = "--s1ds-reconnect-test-cycles";
-        private const string DwellFlag = "--s1ds-reconnect-test-dwell-seconds";
-        private const string StartDelayFlag = "--s1ds-reconnect-test-start-delay-seconds";
-        private const string StartMarkerFlag = "--s1ds-reconnect-test-start-marker";
-        private const string JoinTimeoutFlag = "--s1ds-reconnect-test-join-timeout-seconds";
-        private const string MenuTimeoutFlag = "--s1ds-reconnect-test-menu-timeout-seconds";
-        private const string QuitFlag = "--s1ds-reconnect-test-quit";
+        private const string TEST_FLAG = "--s1ds-reconnect-test";
+        private const string HOST_FLAG = "--s1ds-reconnect-test-host";
+        private const string PORT_FLAG = "--s1ds-reconnect-test-port";
+        private const string CYCLES_FLAG = "--s1ds-reconnect-test-cycles";
+        private const string DWELL_FLAG = "--s1ds-reconnect-test-dwell-seconds";
+        private const string START_DELAY_FLAG = "--s1ds-reconnect-test-start-delay-seconds";
+        private const string START_MARKER_FLAG = "--s1ds-reconnect-test-start-marker";
+        private const string JOIN_TIMEOUT_FLAG = "--s1ds-reconnect-test-join-timeout-seconds";
+        private const string MENU_TIMEOUT_FLAG = "--s1ds-reconnect-test-menu-timeout-seconds";
+        private const string QUIT_FLAG = "--s1ds-reconnect-test-quit";
 
         private readonly ClientConnectionManager _connectionManager;
         private ReconnectTestOptions _options;
@@ -76,6 +76,12 @@ namespace DedicatedServerMod.Client.Core
 
             _started = true;
             Log($"START cycles={_options.Cycles} dwellSeconds={_options.DwellSeconds:F1} startDelaySeconds={_options.StartDelaySeconds:F1} host={_options.Host} port={_options.Port}");
+
+            if (!string.IsNullOrWhiteSpace(_options.ParseError))
+            {
+                Fail(_options.ParseError);
+                yield break;
+            }
 
             if (!string.IsNullOrWhiteSpace(_options.StartMarkerPath))
             {
@@ -232,6 +238,7 @@ namespace DedicatedServerMod.Client.Core
             public float JoinTimeoutSeconds { get; private set; } = 120f;
             public float MenuTimeoutSeconds { get; private set; } = 45f;
             public bool QuitOnComplete { get; private set; } = true;
+            public string ParseError { get; private set; }
 
             public static ReconnectTestOptions Parse(string[] args)
             {
@@ -244,43 +251,53 @@ namespace DedicatedServerMod.Client.Core
                 for (int i = 0; i < args.Length; i++)
                 {
                     string arg = args[i];
-                    if (string.Equals(arg, TestFlag, StringComparison.Ordinal))
+                    if (string.Equals(arg, TEST_FLAG, StringComparison.Ordinal))
                     {
                         options.Enabled = true;
                     }
-                    else if (string.Equals(arg, HostFlag, StringComparison.Ordinal) && TryReadNext(args, i, out string host))
+                    else if (string.Equals(arg, HOST_FLAG, StringComparison.Ordinal) && TryReadNext(args, i, out string host))
                     {
                         options.Host = host;
                     }
-                    else if (string.Equals(arg, PortFlag, StringComparison.Ordinal) && TryReadNext(args, i, out string portText) && int.TryParse(portText, out int port))
+                    else if (string.Equals(arg, PORT_FLAG, StringComparison.Ordinal))
                     {
-                        options.Port = port;
+                        if (!TryReadNext(args, i, out string portText) ||
+                            !int.TryParse(portText, out int port) ||
+                            port < 1 ||
+                            port > 65535)
+                        {
+                            options.ParseError = $"invalid reconnect test port '{portText ?? string.Empty}'";
+                        }
+                        else
+                        {
+                            options.Port = port;
+                        }
                     }
-                    else if (string.Equals(arg, CyclesFlag, StringComparison.Ordinal) && TryReadNext(args, i, out string cyclesText) && int.TryParse(cyclesText, out int cycles))
+                    else if (string.Equals(arg, CYCLES_FLAG, StringComparison.Ordinal) && TryReadNext(args, i, out string cyclesText) && int.TryParse(cyclesText, out int cycles))
                     {
                         options.Cycles = Mathf.Clamp(cycles, 1, 10);
                     }
-                    else if (string.Equals(arg, DwellFlag, StringComparison.Ordinal) && TryReadNext(args, i, out string dwellText) && TryParseFloat(dwellText, out float dwellSeconds))
+                    else if (string.Equals(arg, DWELL_FLAG, StringComparison.Ordinal) && TryReadNext(args, i, out string dwellText) && TryParseFloat(dwellText, out float dwellSeconds))
                     {
                         options.DwellSeconds = Mathf.Clamp(dwellSeconds, 1f, 300f);
                     }
-                    else if (string.Equals(arg, StartDelayFlag, StringComparison.Ordinal) && TryReadNext(args, i, out string startDelayText) && TryParseFloat(startDelayText, out float startDelaySeconds))
+                    else if (string.Equals(arg, START_DELAY_FLAG, StringComparison.Ordinal) && TryReadNext(args, i, out string startDelayText) && TryParseFloat(startDelayText, out float startDelaySeconds))
                     {
                         options.StartDelaySeconds = Mathf.Clamp(startDelaySeconds, 0f, 300f);
                     }
-                    else if (string.Equals(arg, StartMarkerFlag, StringComparison.Ordinal) && TryReadNext(args, i, out string startMarkerPath))
+                    else if (string.Equals(arg, START_MARKER_FLAG, StringComparison.Ordinal) && TryReadNext(args, i, out string startMarkerPath))
                     {
                         options.StartMarkerPath = startMarkerPath;
                     }
-                    else if (string.Equals(arg, JoinTimeoutFlag, StringComparison.Ordinal) && TryReadNext(args, i, out string joinTimeoutText) && TryParseFloat(joinTimeoutText, out float joinTimeoutSeconds))
+                    else if (string.Equals(arg, JOIN_TIMEOUT_FLAG, StringComparison.Ordinal) && TryReadNext(args, i, out string joinTimeoutText) && TryParseFloat(joinTimeoutText, out float joinTimeoutSeconds))
                     {
                         options.JoinTimeoutSeconds = Mathf.Clamp(joinTimeoutSeconds, 10f, 600f);
                     }
-                    else if (string.Equals(arg, MenuTimeoutFlag, StringComparison.Ordinal) && TryReadNext(args, i, out string menuTimeoutText) && TryParseFloat(menuTimeoutText, out float menuTimeoutSeconds))
+                    else if (string.Equals(arg, MENU_TIMEOUT_FLAG, StringComparison.Ordinal) && TryReadNext(args, i, out string menuTimeoutText) && TryParseFloat(menuTimeoutText, out float menuTimeoutSeconds))
                     {
                         options.MenuTimeoutSeconds = Mathf.Clamp(menuTimeoutSeconds, 10f, 300f);
                     }
-                    else if (string.Equals(arg, QuitFlag, StringComparison.Ordinal))
+                    else if (string.Equals(arg, QUIT_FLAG, StringComparison.Ordinal))
                     {
                         options.QuitOnComplete = true;
                     }

--- a/Client/Managers/ClientConnectionManager.cs
+++ b/Client/Managers/ClientConnectionManager.cs
@@ -12,21 +12,39 @@ using FishNet.Transporting.Tugboat;
 using MelonLoader;
 using System.Globalization;
 #if IL2CPP
+using GuidManagerType = Il2Cpp.GUIDManager;
 using Il2CppScheduleOne.DevUtilities;
+using Il2CppScheduleOne.Economy;
 using Il2CppScheduleOne.Networking;
 using Il2CppScheduleOne.Persistence;
+using Il2CppScheduleOne.Quests;
 using Il2CppScheduleOne.PlayerScripts;
 using Il2CppScheduleOne.Audio;
+using Il2CppScheduleOne.AvatarFramework.Animation;
+using Il2CppScheduleOne.Money;
+using Il2CppScheduleOne.Property;
+using Il2CppScheduleOne.Tools;
 using Il2CppScheduleOne.UI;
+using Il2CppScheduleOne.UI.Phone;
 using Il2CppScheduleOne.UI.MainMenu;
+using Il2CppPathfinding;
 using Il2CppSteamworks;
 #else
+using GuidManagerType = global::GUIDManager;
+using Pathfinding;
 using ScheduleOne.Audio;
+using ScheduleOne.AvatarFramework.Animation;
 using ScheduleOne.DevUtilities;
+using ScheduleOne.Economy;
+using ScheduleOne.Money;
 using ScheduleOne.Networking;
 using ScheduleOne.Persistence;
 using ScheduleOne.PlayerScripts;
+using ScheduleOne.Property;
+using ScheduleOne.Quests;
+using ScheduleOne.Tools;
 using ScheduleOne.UI;
+using ScheduleOne.UI.Phone;
 using ScheduleOne.UI.MainMenu;
 using Steamworks;
 #endif
@@ -249,7 +267,7 @@ namespace DedicatedServerMod.Client.Managers
             // --- Step 6 (native 671): CleanUp ---
             // Clears GUIDManager, Quest lists, PlayerList, staggeredReplicators, etc.
             timeline.Mark("CleanUp");
-            CleanUpMethod?.Invoke(loadManager, null);
+            RunLoadManagerCleanUp(loadManager);
 
             // --- Step 7 (native 672-680): Configure transport and set timeout ---
             timeline.Mark("ConfigureTransport");
@@ -421,6 +439,65 @@ namespace DedicatedServerMod.Client.Managers
         private bool ShouldAbortJoinSequence(long joinAttemptId)
         {
             return joinAttemptId != _activeJoinAttemptId || _isReturningToMenu || !IsConnecting;
+        }
+
+        private static void RunLoadManagerCleanUp(LoadManager loadManager)
+        {
+            bool reflectedCleanUpSucceeded = false;
+            if (CleanUpMethod != null)
+            {
+                try
+                {
+                    CleanUpMethod.Invoke(loadManager, null);
+                    reflectedCleanUpSucceeded = true;
+                }
+                catch (Exception ex)
+                {
+                    DebugLog.Warning($"LoadManager.CleanUp reflection failed; applying dedicated client cleanup fallback: {ex.Message}");
+                }
+            }
+
+            try
+            {
+                ClearCriticalLoadState(loadManager);
+            }
+            catch (Exception ex)
+            {
+                DebugLog.Warning($"Dedicated client cleanup fallback failed: {ex.Message}");
+            }
+
+            if (!reflectedCleanUpSucceeded)
+            {
+                DebugLog.Debug("Applied dedicated client cleanup fallback without native LoadManager.CleanUp.");
+            }
+        }
+
+        private static void ClearCriticalLoadState(LoadManager loadManager)
+        {
+            GuidManagerType.Clear();
+            Quest.Quests.Clear();
+            Quest.ActiveQuests.Clear();
+            NodeLink.validNodeLinks.Clear();
+            Player.onLocalPlayerSpawned = null;
+            Player.PlayerList.Clear();
+            SupplierLocation.AllLocations.Clear();
+            Phone.ActiveApp = null;
+            ATM.WeeklyDepositSum = 0f;
+            NavMeshUtility.ClearCache();
+            Business.OwnedBusinesses.Clear();
+            Business.UnownedBusinesses.Clear();
+            Business.onOperationFinished = null;
+            Business.onOperationStarted = null;
+            Property.onPropertyAcquired = null;
+            Property.OwnedProperties.Clear();
+            Property.UnownedProperties.Clear();
+            PlayerMovement.StaticMoveSpeedMultiplier = 1f;
+            AvatarLookController.TempContainer = null;
+            Customer.onCustomerUnlocked = null;
+            Customer.UnlockedCustomers.Clear();
+            Customer.LockedCustomers.Clear();
+            loadManager.staggeredReplicators.Clear();
+            ManagementClipboard_Equippable.ResetHeatmapToggle();
         }
 
         /// <summary>

--- a/Client/Managers/ClientConnectionManager.cs
+++ b/Client/Managers/ClientConnectionManager.cs
@@ -457,14 +457,7 @@ namespace DedicatedServerMod.Client.Managers
                 }
             }
 
-            try
-            {
-                ClearCriticalLoadState(loadManager);
-            }
-            catch (Exception ex)
-            {
-                DebugLog.Warning($"Dedicated client cleanup fallback failed: {ex.Message}");
-            }
+            ClearCriticalLoadState(loadManager);
 
             if (!reflectedCleanUpSucceeded)
             {
@@ -474,30 +467,42 @@ namespace DedicatedServerMod.Client.Managers
 
         private static void ClearCriticalLoadState(LoadManager loadManager)
         {
-            GuidManagerType.Clear();
-            Quest.Quests.Clear();
-            Quest.ActiveQuests.Clear();
-            NodeLink.validNodeLinks.Clear();
-            Player.onLocalPlayerSpawned = null;
-            Player.PlayerList.Clear();
-            SupplierLocation.AllLocations.Clear();
-            Phone.ActiveApp = null;
-            ATM.WeeklyDepositSum = 0f;
-            NavMeshUtility.ClearCache();
-            Business.OwnedBusinesses.Clear();
-            Business.UnownedBusinesses.Clear();
-            Business.onOperationFinished = null;
-            Business.onOperationStarted = null;
-            Property.onPropertyAcquired = null;
-            Property.OwnedProperties.Clear();
-            Property.UnownedProperties.Clear();
-            PlayerMovement.StaticMoveSpeedMultiplier = 1f;
-            AvatarLookController.TempContainer = null;
-            Customer.onCustomerUnlocked = null;
-            Customer.UnlockedCustomers.Clear();
-            Customer.LockedCustomers.Clear();
-            loadManager.staggeredReplicators.Clear();
-            ManagementClipboard_Equippable.ResetHeatmapToggle();
+            TryClearLoadState("GUIDManager.Clear", () => GuidManagerType.Clear());
+            TryClearLoadState("Quest.Quests.Clear", () => Quest.Quests.Clear());
+            TryClearLoadState("Quest.ActiveQuests.Clear", () => Quest.ActiveQuests.Clear());
+            TryClearLoadState("NodeLink.validNodeLinks.Clear", () => NodeLink.validNodeLinks.Clear());
+            TryClearLoadState("Player.onLocalPlayerSpawned", () => Player.onLocalPlayerSpawned = null);
+            TryClearLoadState("Player.PlayerList.Clear", () => Player.PlayerList.Clear());
+            TryClearLoadState("SupplierLocation.AllLocations.Clear", () => SupplierLocation.AllLocations.Clear());
+            TryClearLoadState("Phone.ActiveApp", () => Phone.ActiveApp = null);
+            TryClearLoadState("ATM.WeeklyDepositSum", () => ATM.WeeklyDepositSum = 0f);
+            TryClearLoadState("NavMeshUtility.ClearCache", () => NavMeshUtility.ClearCache());
+            TryClearLoadState("Business.OwnedBusinesses.Clear", () => Business.OwnedBusinesses.Clear());
+            TryClearLoadState("Business.UnownedBusinesses.Clear", () => Business.UnownedBusinesses.Clear());
+            TryClearLoadState("Business.onOperationFinished", () => Business.onOperationFinished = null);
+            TryClearLoadState("Business.onOperationStarted", () => Business.onOperationStarted = null);
+            TryClearLoadState("Property.onPropertyAcquired", () => Property.onPropertyAcquired = null);
+            TryClearLoadState("Property.OwnedProperties.Clear", () => Property.OwnedProperties.Clear());
+            TryClearLoadState("Property.UnownedProperties.Clear", () => Property.UnownedProperties.Clear());
+            TryClearLoadState("PlayerMovement.StaticMoveSpeedMultiplier", () => PlayerMovement.StaticMoveSpeedMultiplier = 1f);
+            TryClearLoadState("AvatarLookController.TempContainer", () => AvatarLookController.TempContainer = null);
+            TryClearLoadState("Customer.onCustomerUnlocked", () => Customer.onCustomerUnlocked = null);
+            TryClearLoadState("Customer.UnlockedCustomers.Clear", () => Customer.UnlockedCustomers.Clear());
+            TryClearLoadState("Customer.LockedCustomers.Clear", () => Customer.LockedCustomers.Clear());
+            TryClearLoadState("LoadManager.staggeredReplicators.Clear", () => loadManager?.staggeredReplicators?.Clear());
+            TryClearLoadState("ManagementClipboard_Equippable.ResetHeatmapToggle", () => ManagementClipboard_Equippable.ResetHeatmapToggle());
+        }
+
+        private static void TryClearLoadState(string step, Action clear)
+        {
+            try
+            {
+                clear?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                DebugLog.Warning($"Dedicated client cleanup fallback step '{step}' failed: {ex.Message}");
+            }
         }
 
         /// <summary>

--- a/Client/Managers/ClientConnectionManager.cs
+++ b/Client/Managers/ClientConnectionManager.cs
@@ -10,6 +10,7 @@ using FishNet.Transporting.Multipass;
 using FishNet.Transporting.Tugboat;
 #endif
 using MelonLoader;
+using System.Globalization;
 #if IL2CPP
 using Il2CppScheduleOne.DevUtilities;
 using Il2CppScheduleOne.Networking;
@@ -18,6 +19,7 @@ using Il2CppScheduleOne.PlayerScripts;
 using Il2CppScheduleOne.Audio;
 using Il2CppScheduleOne.UI;
 using Il2CppScheduleOne.UI.MainMenu;
+using Il2CppSteamworks;
 #else
 using ScheduleOne.Audio;
 using ScheduleOne.DevUtilities;
@@ -26,6 +28,7 @@ using ScheduleOne.Persistence;
 using ScheduleOne.PlayerScripts;
 using ScheduleOne.UI;
 using ScheduleOne.UI.MainMenu;
+using Steamworks;
 #endif
 using System;
 using System.Collections;
@@ -42,6 +45,7 @@ using DedicatedServerMod.Utils;
 using Newtonsoft.Json;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using DSConstants = DedicatedServerMod.Utils.Constants;
 
 namespace DedicatedServerMod.Client.Managers
 {
@@ -488,6 +492,91 @@ namespace DedicatedServerMod.Client.Managers
 #else
             Player.onLocalPlayerSpawned -= new Action(OnLocalPlayerSpawned);
 #endif
+
+            ClientBootstrap.Instance?.ConnectionManager?.StartLocalPlayerIdentityRecovery();
+        }
+
+        private void StartLocalPlayerIdentityRecovery()
+        {
+            MelonCoroutines.Start(RecoverLocalPlayerIdentityAfterSpawn());
+        }
+
+        private IEnumerator RecoverLocalPlayerIdentityAfterSpawn()
+        {
+            yield return new WaitForSeconds(0.5f);
+
+            if (!IsConnecting || _isReturningToMenu)
+            {
+                yield break;
+            }
+
+            var localPlayer = Player.Local;
+            if (localPlayer == null || localPlayer.playerDataRetrieveReturned)
+            {
+                yield break;
+            }
+
+            if (!ClientSteamRuntime.EnsureUserReady(attemptInitialization: true, out ulong steamId, out string steamStatus))
+            {
+                DebugLog.Warning($"Dedicated client could not recover local player identity after spawn: {steamStatus}");
+                yield break;
+            }
+
+            string playerName = ResolveSteamPersonaName(localPlayer);
+            string steamIdText = steamId.ToString(CultureInfo.InvariantCulture);
+
+            try
+            {
+                localPlayer.SendPlayerNameData(playerName, steamId);
+                DebugLog.PlayerLifecycleDebug($"Recovered local player identity after spawn: {playerName} ({steamIdText})");
+            }
+            catch (Exception ex)
+            {
+                DebugLog.Warning($"Failed to resend local player identity after spawn: {ex.Message}");
+            }
+
+            try
+            {
+                if (!InstanceFinder.IsServer)
+                {
+                    localPlayer.RequestPlayerData(steamIdText);
+                    DebugLog.PlayerLifecycleDebug($"Requested player data after identity recovery for SteamID {steamIdText}");
+                }
+            }
+            catch (Exception ex)
+            {
+                DebugLog.Warning($"Failed to request player data after identity recovery: {ex.Message}");
+            }
+        }
+
+        private static string ResolveSteamPersonaName(Player localPlayer)
+        {
+            try
+            {
+                string personaName = SteamFriends.GetPersonaName();
+                if (!string.IsNullOrWhiteSpace(personaName))
+                {
+                    return personaName;
+                }
+            }
+            catch (Exception ex)
+            {
+                DebugLog.Warning($"Failed to read Steam persona name during identity recovery: {ex.Message}");
+            }
+
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(localPlayer?.PlayerName))
+                {
+                    return localPlayer.PlayerName;
+                }
+            }
+            catch (Exception ex)
+            {
+                DebugLog.Warning($"Failed to read local player name during identity recovery: {ex.Message}");
+            }
+
+            return "Player";
         }
 
         private void HandleConnectionError(string errorMessage)
@@ -825,7 +914,7 @@ namespace DedicatedServerMod.Client.Managers
 
         private void OnClientMessageReceived(string command, string data)
         {
-            if (!string.Equals(command, Constants.Messages.DisconnectNotice, StringComparison.Ordinal))
+            if (!string.Equals(command, DSConstants.Messages.DisconnectNotice, StringComparison.Ordinal))
             {
                 return;
             }

--- a/Client/Patches/ClientRuntimeStabilityPatches.cs
+++ b/Client/Patches/ClientRuntimeStabilityPatches.cs
@@ -2,13 +2,21 @@ using System;
 using HarmonyLib;
 using DedicatedServerMod.Utils;
 #if IL2CPP
+using ConfigurationServiceNetworkerType = Il2CppScheduleOne.Configuration.ConfigurationServiceNetworker;
 using Il2CppScheduleOne.DevUtilities;
+using NPCActionType = Il2CppScheduleOne.NPCs.Schedules.NPCAction;
+using NPCEventStayInBuildingType = Il2CppScheduleOne.NPCs.Schedules.NPCEvent_StayInBuilding;
+using NPCType = Il2CppScheduleOne.NPCs.NPC;
 using Il2CppScheduleOne.PlayerScripts;
 using MessageType = Il2CppScheduleOne.Messaging.Message;
 using MSGConversationType = Il2CppScheduleOne.Messaging.MSGConversation;
 using TrashItemType = Il2CppScheduleOne.Trash.TrashItem;
 #else
+using ConfigurationServiceNetworkerType = ScheduleOne.Configuration.ConfigurationServiceNetworker;
 using ScheduleOne.DevUtilities;
+using NPCActionType = ScheduleOne.NPCs.Schedules.NPCAction;
+using NPCEventStayInBuildingType = ScheduleOne.NPCs.Schedules.NPCEvent_StayInBuilding;
+using NPCType = ScheduleOne.NPCs.NPC;
 using ScheduleOne.PlayerScripts;
 using MessageType = ScheduleOne.Messaging.Message;
 using MSGConversationType = ScheduleOne.Messaging.MSGConversation;
@@ -55,6 +63,58 @@ namespace DedicatedServerMod.Client.Patches
             }
 
             return __exception;
+        }
+    }
+
+    /// <summary>
+    /// Skips stale NPC building-entry animation RPCs when reconnect scene cleanup has left
+    /// the client-side NPC action without the object graph required by its coroutine.
+    /// </summary>
+    [HarmonyPatch(typeof(NPCEventStayInBuildingType), "RpcLogic___PlayEnterAnimation_2166136261")]
+    internal static class NPCEventStayInBuildingEnterAnimationClientPatches
+    {
+        private static readonly System.Reflection.FieldInfo NpcField =
+            AccessTools.Field(typeof(NPCActionType), "npc");
+
+        private static bool Prefix(NPCEventStayInBuildingType __instance)
+        {
+            try
+            {
+                if (__instance == null || !CoroutineService.InstanceExists)
+                {
+                    return false;
+                }
+
+                var npc = NpcField?.GetValue(__instance) as NPCType;
+                if (npc == null ||
+                    npc.Movement == null ||
+                    npc.Avatar == null ||
+                    npc.Avatar.Animation == null)
+                {
+                    DebugLog.Warning("Suppressed stale NPCEvent_StayInBuilding enter animation during client reconnect cleanup.");
+                    return false;
+                }
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                DebugLog.Warning($"Suppressed NPCEvent_StayInBuilding enter animation after validation failed: {ex.Message}");
+                return false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Avoids client shutdown cleanup calling server-only configuration listener removal
+    /// when the configuration singleton has already been destroyed.
+    /// </summary>
+    [HarmonyPatch(typeof(ConfigurationServiceNetworkerType), "OnDestroy")]
+    internal static class ConfigurationServiceNetworkerOnDestroyClientPatches
+    {
+        private static bool Prefix(ConfigurationServiceNetworkerType __instance)
+        {
+            return __instance != null && __instance.IsServerInitialized;
         }
     }
 }

--- a/Client/Patches/ClientRuntimeStabilityPatches.cs
+++ b/Client/Patches/ClientRuntimeStabilityPatches.cs
@@ -76,15 +76,16 @@ namespace DedicatedServerMod.Client.Patches
         private static readonly System.Reflection.FieldInfo NpcField =
             AccessTools.Field(typeof(NPCActionType), "npc");
 
+        [HarmonyPrepare]
+        private static bool Prepare()
+        {
+            return NpcField != null;
+        }
+
         private static bool Prefix(NPCEventStayInBuildingType __instance)
         {
             try
             {
-                if (NpcField == null)
-                {
-                    return true;
-                }
-
                 if (__instance == null || !CoroutineService.InstanceExists)
                 {
                     return false;

--- a/Client/Patches/ClientRuntimeStabilityPatches.cs
+++ b/Client/Patches/ClientRuntimeStabilityPatches.cs
@@ -80,6 +80,11 @@ namespace DedicatedServerMod.Client.Patches
         {
             try
             {
+                if (NpcField == null)
+                {
+                    return true;
+                }
+
                 if (__instance == null || !CoroutineService.InstanceExists)
                 {
                     return false;

--- a/DedicatedServerMod.csproj
+++ b/DedicatedServerMod.csproj
@@ -765,6 +765,7 @@
 
 		<!-- Client bootstrap and entry point -->
 		<Compile Include="Client\Core\ClientBootstrap.cs" />
+		<Compile Include="Client\Core\ClientReconnectTestRunner.cs" />
 		<Compile Include="Client\Core\ClientSteamRuntime.cs" />
 
 		<!-- Client managers -->

--- a/Server/Game/Patches/Gameplay/NpcBehaviourPatches.cs
+++ b/Server/Game/Patches/Gameplay/NpcBehaviourPatches.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using HarmonyLib;
 using DedicatedServerMod.Utils;
 using UnityEngine;
@@ -6,12 +7,14 @@ using UnityEngine;
 using BehaviourType = Il2CppScheduleOne.NPCs.Behaviour.Behaviour;
 using BehaviourListType = Il2CppSystem.Collections.Generic.List<Il2CppScheduleOne.NPCs.Behaviour.Behaviour>;
 using NpcBehaviourType = Il2CppScheduleOne.NPCs.Behaviour.NPCBehaviour;
+using PlayerType = Il2CppScheduleOne.PlayerScripts.Player;
 using PursuitBehaviourType = Il2CppScheduleOne.NPCs.Behaviour.PursuitBehaviour;
 using VehiclePursuitBehaviourType = Il2CppScheduleOne.NPCs.Behaviour.VehiclePursuitBehaviour;
 #else
 using BehaviourType = ScheduleOne.NPCs.Behaviour.Behaviour;
 using BehaviourListType = System.Collections.Generic.List<ScheduleOne.NPCs.Behaviour.Behaviour>;
 using NpcBehaviourType = ScheduleOne.NPCs.Behaviour.NPCBehaviour;
+using PlayerType = ScheduleOne.PlayerScripts.Player;
 using PursuitBehaviourType = ScheduleOne.NPCs.Behaviour.PursuitBehaviour;
 using VehiclePursuitBehaviourType = ScheduleOne.NPCs.Behaviour.VehiclePursuitBehaviour;
 #endif
@@ -105,13 +108,55 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
                 return false;
             }
 
-            if (behaviour is PursuitBehaviourType || behaviour is VehiclePursuitBehaviourType)
+            try
             {
+                if (behaviour is PursuitBehaviourType pursuit)
+                {
+                    return DedicatedPolicePursuitAuthority.IsInvalidOrDisconnectedTarget(pursuit.TargetPlayer);
+                }
+
+                if (behaviour is VehiclePursuitBehaviourType vehiclePursuit)
+                {
+                    return DedicatedPolicePursuitAuthority.IsInvalidOrDisconnectedTarget(vehiclePursuit.Target);
+                }
+
+                string typeName = behaviour.GetType()?.FullName ?? string.Empty;
+                if (typeName.IndexOf("BodySearchBehaviour", StringComparison.Ordinal) < 0)
+                {
+                    return false;
+                }
+
+                return TryGetPlayerTarget(behaviour, out PlayerType target)
+                    && DedicatedPolicePursuitAuthority.IsInvalidOrDisconnectedTarget(target);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private static bool TryGetPlayerTarget(BehaviourType behaviour, out PlayerType target)
+        {
+            target = null;
+
+            Type behaviourType = behaviour.GetType();
+            PropertyInfo property = AccessTools.Property(behaviourType, "TargetPlayer");
+            object value = property?.GetValue(behaviour);
+            if (value is PlayerType propertyTarget)
+            {
+                target = propertyTarget;
                 return true;
             }
 
-            string typeName = behaviour.GetType()?.FullName ?? string.Empty;
-            return typeName.IndexOf("BodySearchBehaviour", StringComparison.Ordinal) >= 0;
+            FieldInfo field = AccessTools.Field(behaviourType, "TargetPlayer");
+            value = field?.GetValue(behaviour);
+            if (value is PlayerType fieldTarget)
+            {
+                target = fieldTarget;
+                return true;
+            }
+
+            return false;
         }
     }
 }

--- a/Server/Game/Patches/Gameplay/NpcBehaviourPatches.cs
+++ b/Server/Game/Patches/Gameplay/NpcBehaviourPatches.cs
@@ -6,10 +6,14 @@ using UnityEngine;
 using BehaviourType = Il2CppScheduleOne.NPCs.Behaviour.Behaviour;
 using BehaviourListType = Il2CppSystem.Collections.Generic.List<Il2CppScheduleOne.NPCs.Behaviour.Behaviour>;
 using NpcBehaviourType = Il2CppScheduleOne.NPCs.Behaviour.NPCBehaviour;
+using PursuitBehaviourType = Il2CppScheduleOne.NPCs.Behaviour.PursuitBehaviour;
+using VehiclePursuitBehaviourType = Il2CppScheduleOne.NPCs.Behaviour.VehiclePursuitBehaviour;
 #else
 using BehaviourType = ScheduleOne.NPCs.Behaviour.Behaviour;
 using BehaviourListType = System.Collections.Generic.List<ScheduleOne.NPCs.Behaviour.Behaviour>;
 using NpcBehaviourType = ScheduleOne.NPCs.Behaviour.NPCBehaviour;
+using PursuitBehaviourType = ScheduleOne.NPCs.Behaviour.PursuitBehaviour;
+using VehiclePursuitBehaviourType = ScheduleOne.NPCs.Behaviour.VehiclePursuitBehaviour;
 #endif
 
 namespace DedicatedServerMod.Server.Game.Patches.Gameplay
@@ -17,6 +21,8 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
     /// <summary>
     /// Removes per-frame LINQ allocation and reflection overhead from NPC behavior selection on dedicated headless servers.
     /// Uses the Krafs-publicized <c>enabledBehaviours</c> field directly so the hot path stays out of <see cref="Utils.SafeReflection"/>.
+    /// Also throttles repeated stale police-behaviour exceptions behind one shared cooldown so disconnect cleanup can recover
+    /// invalid pursuit targets without sweeping every NPC instance or flooding logs every frame.
     /// </summary>
     [HarmonyPatch(typeof(NpcBehaviourType), "Update")]
     internal static class NpcBehaviourUpdatePatches
@@ -68,6 +74,11 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
                 }
                 catch (Exception ex)
                 {
+                    if (!ShouldRecoverFromStalePoliceTarget(__instance.activeBehaviour))
+                    {
+                        throw;
+                    }
+
                     _suppressedStaleBehaviourExceptions++;
                     float now = Time.realtimeSinceStartup;
                     if (now - _lastStaleBehaviourCleanupTime < STALE_BEHAVIOUR_CLEANUP_COOLDOWN_SECONDS)
@@ -85,6 +96,22 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
             }
 
             return false;
+        }
+
+        private static bool ShouldRecoverFromStalePoliceTarget(BehaviourType behaviour)
+        {
+            if (behaviour == null)
+            {
+                return false;
+            }
+
+            if (behaviour is PursuitBehaviourType || behaviour is VehiclePursuitBehaviourType)
+            {
+                return true;
+            }
+
+            string typeName = behaviour.GetType()?.FullName ?? string.Empty;
+            return typeName.IndexOf("BodySearchBehaviour", StringComparison.Ordinal) >= 0;
         }
     }
 }

--- a/Server/Game/Patches/Gameplay/NpcBehaviourPatches.cs
+++ b/Server/Game/Patches/Gameplay/NpcBehaviourPatches.cs
@@ -1,6 +1,7 @@
 using System;
 using HarmonyLib;
 using DedicatedServerMod.Utils;
+using UnityEngine;
 #if IL2CPP
 using BehaviourType = Il2CppScheduleOne.NPCs.Behaviour.Behaviour;
 using BehaviourListType = Il2CppSystem.Collections.Generic.List<Il2CppScheduleOne.NPCs.Behaviour.Behaviour>;
@@ -20,6 +21,11 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
     [HarmonyPatch(typeof(NpcBehaviourType), "Update")]
     internal static class NpcBehaviourUpdatePatches
     {
+        private const float STALE_BEHAVIOUR_CLEANUP_COOLDOWN_SECONDS = 3f;
+
+        private static float _lastStaleBehaviourCleanupTime = -STALE_BEHAVIOUR_CLEANUP_COOLDOWN_SECONDS;
+        private static int _suppressedStaleBehaviourExceptions;
+
         private static bool Prefix(NpcBehaviourType __instance)
         {
             if (__instance == null || __instance.DEBUG_MODE)
@@ -62,8 +68,19 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
                 }
                 catch (Exception ex)
                 {
+                    _suppressedStaleBehaviourExceptions++;
+                    float now = Time.realtimeSinceStartup;
+                    if (now - _lastStaleBehaviourCleanupTime < STALE_BEHAVIOUR_CLEANUP_COOLDOWN_SECONDS)
+                    {
+                        return false;
+                    }
+
+                    _lastStaleBehaviourCleanupTime = now;
+                    int suppressedCount = _suppressedStaleBehaviourExceptions;
+                    _suppressedStaleBehaviourExceptions = 0;
+
                     DedicatedPolicePursuitAuthority.ClearInvalidPoliceTargets();
-                    DebugLog.Warning($"Suppressed stale NPC behaviour update after dedicated target cleanup: {ex.Message}");
+                    DebugLog.Warning($"Suppressed {suppressedCount} stale NPC behaviour update exception(s) after dedicated target cleanup: {ex.Message}");
                 }
             }
 

--- a/Server/Game/Patches/Gameplay/NpcBehaviourPatches.cs
+++ b/Server/Game/Patches/Gameplay/NpcBehaviourPatches.cs
@@ -1,4 +1,6 @@
+using System;
 using HarmonyLib;
+using DedicatedServerMod.Utils;
 #if IL2CPP
 using BehaviourType = Il2CppScheduleOne.NPCs.Behaviour.Behaviour;
 using BehaviourListType = Il2CppSystem.Collections.Generic.List<Il2CppScheduleOne.NPCs.Behaviour.Behaviour>;
@@ -54,7 +56,15 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
 
             if (__instance.activeBehaviour != null && __instance.activeBehaviour.Active)
             {
-                __instance.activeBehaviour.BehaviourUpdate();
+                try
+                {
+                    __instance.activeBehaviour.BehaviourUpdate();
+                }
+                catch (Exception ex)
+                {
+                    DedicatedPolicePursuitAuthority.ClearInvalidPoliceTargets();
+                    DebugLog.Warning($"Suppressed stale NPC behaviour update after dedicated target cleanup: {ex.Message}");
+                }
             }
 
             return false;

--- a/Server/Game/Patches/Gameplay/PolicePursuitPatches.cs
+++ b/Server/Game/Patches/Gameplay/PolicePursuitPatches.cs
@@ -1,6 +1,7 @@
 using DedicatedServerMod.Server.Game.Patches.Common;
 using DedicatedServerMod.Utils;
 using HarmonyLib;
+using System.Collections.Generic;
 using System.Reflection;
 using UnityEngine;
 #if IL2CPP
@@ -94,14 +95,8 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
                 return;
             }
 
-            for (int i = 0; i < PoliceOfficerType.Officers.Count; i++)
+            ForEachOfficer(officer =>
             {
-                PoliceOfficerType officer = PoliceOfficerType.Officers[i];
-                if (officer == null)
-                {
-                    continue;
-                }
-
                 if (officer.BodySearchBehaviour != null
                     && officer.BodySearchBehaviour.Enabled
                     && officer.BodySearchBehaviour.TargetPlayer == player)
@@ -122,7 +117,7 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
                 {
                     TryDisable(() => officer.VehiclePursuitBehaviour.Disable_Networked(null));
                 }
-            }
+            });
         }
 
         internal static void ClearInvalidPoliceTargets()
@@ -132,14 +127,8 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
                 return;
             }
 
-            for (int i = 0; i < PoliceOfficerType.Officers.Count; i++)
+            ForEachOfficer(officer =>
             {
-                PoliceOfficerType officer = PoliceOfficerType.Officers[i];
-                if (officer == null)
-                {
-                    continue;
-                }
-
                 PlayerType bodySearchTarget = officer.BodySearchBehaviour?.TargetPlayer;
                 if (officer.BodySearchBehaviour != null
                     && officer.BodySearchBehaviour.Enabled
@@ -163,7 +152,7 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
                 {
                     TryDisable(() => officer.VehiclePursuitBehaviour.Disable_Networked(null));
                 }
-            }
+            });
         }
 
         internal static void RefreshServerSight(PlayerType player)
@@ -242,6 +231,49 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
             return method.Invoke(instance, null) is bool visible && visible;
         }
 
+        private static void ForEachOfficer(System.Action<PoliceOfficerType> handleOfficer)
+        {
+            if (handleOfficer == null)
+            {
+                return;
+            }
+
+            var officers = PoliceOfficerType.Officers;
+            if (officers == null)
+            {
+                return;
+            }
+
+            var snapshot = new List<PoliceOfficerType>(officers.Count);
+            try
+            {
+                for (int i = 0; i < officers.Count; i++)
+                {
+                    PoliceOfficerType officer = officers[i];
+                    if (officer != null)
+                    {
+                        snapshot.Add(officer);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                DebugLog.Warning("Failed while snapshotting officers for stale police target cleanup.", ex);
+            }
+
+            for (int i = 0; i < snapshot.Count; i++)
+            {
+                try
+                {
+                    handleOfficer(snapshot[i]);
+                }
+                catch (Exception ex)
+                {
+                    DebugLog.Warning("Failed while scanning officer for stale police target cleanup.", ex);
+                }
+            }
+        }
+
         private static void TryDisable(Action disable)
         {
             try
@@ -281,9 +313,9 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
             return false;
         }
 
-        private static void Postfix(CombatBehaviourType __instance)
+        private static void Postfix(CombatBehaviourType __instance, bool __runOriginal)
         {
-            if (!DedicatedServerPatchCommon.IsDedicatedHeadlessServer() || !InstanceFinderType.IsServer)
+            if (!__runOriginal || !DedicatedServerPatchCommon.IsDedicatedHeadlessServer() || !InstanceFinderType.IsServer)
             {
                 return;
             }
@@ -310,6 +342,10 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
         }
     }
 
+    /// <summary>
+    /// Patches <c>CombatBehaviour.BehaviourUpdate</c> on dedicated servers to skip
+    /// vanilla combat processing after a pursuit target becomes invalid or disconnected.
+    /// </summary>
     [HarmonyPatch(typeof(CombatBehaviourType), "BehaviourUpdate")]
     internal static class CombatBehaviourUpdatePatches
     {
@@ -331,6 +367,10 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
         }
     }
 
+    /// <summary>
+    /// Patches <c>PursuitBehaviour.BehaviourUpdate</c> on dedicated servers to clear
+    /// stale pursuit targets and return false before vanilla dereferences them.
+    /// </summary>
     [HarmonyPatch(typeof(PursuitBehaviourType), "BehaviourUpdate")]
     internal static class PursuitBehaviourUpdatePatches
     {

--- a/Server/Game/Patches/Gameplay/PolicePursuitPatches.cs
+++ b/Server/Game/Patches/Gameplay/PolicePursuitPatches.cs
@@ -59,9 +59,37 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
                 || player.CrimeData.CurrentPursuitLevel == PlayerCrimeDataType.EPursuitLevel.None;
         }
 
+        internal static bool IsInvalidOrDisconnectedTarget(PlayerType player)
+        {
+            if (player == null || DedicatedServerPatchCommon.IsGhostOrLoopbackPlayer(player))
+            {
+                return true;
+            }
+
+            try
+            {
+                if (player.Owner == null ||
+                    !player.Owner.IsActive ||
+                    player.NetworkObject == null ||
+                    player.Avatar == null ||
+                    player.CrimeData == null)
+                {
+                    return true;
+                }
+
+                return player.IsArrested
+                    || player.IsUnconscious
+                    || player.CrimeData.CurrentPursuitLevel == PlayerCrimeDataType.EPursuitLevel.None;
+            }
+            catch
+            {
+                return true;
+            }
+        }
+
         internal static void ClearPoliceTargeting(PlayerType player)
         {
-            if (!ShouldRunForPlayer(player) || player.NetworkObject == null)
+            if (player == null || DedicatedServerPatchCommon.IsGhostOrLoopbackPlayer(player))
             {
                 return;
             }
@@ -78,21 +106,62 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
                     && officer.BodySearchBehaviour.Enabled
                     && officer.BodySearchBehaviour.TargetPlayer == player)
                 {
-                    officer.BodySearchBehaviour.Disable_Networked(null);
+                    TryDisable(() => officer.BodySearchBehaviour.Disable_Networked(null));
                 }
 
                 if (officer.PursuitBehaviour != null
                     && officer.PursuitBehaviour.Enabled
                     && officer.PursuitBehaviour.TargetPlayer == player)
                 {
-                    officer.PursuitBehaviour.Disable_Networked(null);
+                    TryDisable(() => officer.PursuitBehaviour.Disable_Networked(null));
                 }
 
                 if (officer.VehiclePursuitBehaviour != null
                     && officer.VehiclePursuitBehaviour.Enabled
                     && officer.VehiclePursuitBehaviour.Target == player)
                 {
-                    officer.VehiclePursuitBehaviour.Disable_Networked(null);
+                    TryDisable(() => officer.VehiclePursuitBehaviour.Disable_Networked(null));
+                }
+            }
+        }
+
+        internal static void ClearInvalidPoliceTargets()
+        {
+            if (!DedicatedServerPatchCommon.IsDedicatedHeadlessServer() || !InstanceFinderType.IsServer)
+            {
+                return;
+            }
+
+            for (int i = 0; i < PoliceOfficerType.Officers.Count; i++)
+            {
+                PoliceOfficerType officer = PoliceOfficerType.Officers[i];
+                if (officer == null)
+                {
+                    continue;
+                }
+
+                PlayerType bodySearchTarget = officer.BodySearchBehaviour?.TargetPlayer;
+                if (officer.BodySearchBehaviour != null
+                    && officer.BodySearchBehaviour.Enabled
+                    && IsInvalidOrDisconnectedTarget(bodySearchTarget))
+                {
+                    TryDisable(() => officer.BodySearchBehaviour.Disable_Networked(null));
+                }
+
+                PlayerType pursuitTarget = officer.PursuitBehaviour?.TargetPlayer;
+                if (officer.PursuitBehaviour != null
+                    && officer.PursuitBehaviour.Enabled
+                    && IsInvalidOrDisconnectedTarget(pursuitTarget))
+                {
+                    TryDisable(() => officer.PursuitBehaviour.Disable_Networked(null));
+                }
+
+                PlayerType vehicleTarget = officer.VehiclePursuitBehaviour?.Target;
+                if (officer.VehiclePursuitBehaviour != null
+                    && officer.VehiclePursuitBehaviour.Enabled
+                    && IsInvalidOrDisconnectedTarget(vehicleTarget))
+                {
+                    TryDisable(() => officer.VehiclePursuitBehaviour.Disable_Networked(null));
                 }
             }
         }
@@ -172,6 +241,18 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
 
             return method.Invoke(instance, null) is bool visible && visible;
         }
+
+        private static void TryDisable(Action disable)
+        {
+            try
+            {
+                disable?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                DebugLog.Warning($"Failed to clear stale police target: {ex.Message}");
+            }
+        }
     }
 
     /// <summary>
@@ -183,6 +264,23 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
     [HarmonyPatch(typeof(CombatBehaviourType), "CheckTargetVisibility")]
     internal static class CombatBehaviourCheckTargetVisibilityPatches
     {
+        private static bool Prefix(CombatBehaviourType __instance)
+        {
+            if (!DedicatedServerPatchCommon.IsDedicatedHeadlessServer() || !InstanceFinderType.IsServer)
+            {
+                return true;
+            }
+
+            PursuitBehaviourType pursuit = __instance as PursuitBehaviourType;
+            if (pursuit == null || !DedicatedPolicePursuitAuthority.IsInvalidOrDisconnectedTarget(pursuit.TargetPlayer))
+            {
+                return true;
+            }
+
+            DedicatedPolicePursuitAuthority.ClearPoliceTargeting(pursuit.TargetPlayer);
+            return false;
+        }
+
         private static void Postfix(CombatBehaviourType __instance)
         {
             if (!DedicatedServerPatchCommon.IsDedicatedHeadlessServer() || !InstanceFinderType.IsServer)
@@ -209,6 +307,47 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
 
             SafeReflection.TrySetInstanceFieldOrProperty(__instance, "visionEventReceived", true);
             DedicatedPolicePursuitAuthority.RefreshServerSight(targetPlayer);
+        }
+    }
+
+    [HarmonyPatch(typeof(CombatBehaviourType), "BehaviourUpdate")]
+    internal static class CombatBehaviourUpdatePatches
+    {
+        private static bool Prefix(CombatBehaviourType __instance)
+        {
+            if (!DedicatedServerPatchCommon.IsDedicatedHeadlessServer() || !InstanceFinderType.IsServer)
+            {
+                return true;
+            }
+
+            PursuitBehaviourType pursuit = __instance as PursuitBehaviourType;
+            if (pursuit == null || !DedicatedPolicePursuitAuthority.IsInvalidOrDisconnectedTarget(pursuit.TargetPlayer))
+            {
+                return true;
+            }
+
+            DedicatedPolicePursuitAuthority.ClearPoliceTargeting(pursuit.TargetPlayer);
+            return false;
+        }
+    }
+
+    [HarmonyPatch(typeof(PursuitBehaviourType), "BehaviourUpdate")]
+    internal static class PursuitBehaviourUpdatePatches
+    {
+        private static bool Prefix(PursuitBehaviourType __instance)
+        {
+            if (!DedicatedServerPatchCommon.IsDedicatedHeadlessServer() || !InstanceFinderType.IsServer || __instance == null)
+            {
+                return true;
+            }
+
+            if (!DedicatedPolicePursuitAuthority.IsInvalidOrDisconnectedTarget(__instance.TargetPlayer))
+            {
+                return true;
+            }
+
+            DedicatedPolicePursuitAuthority.ClearPoliceTargeting(__instance.TargetPlayer);
+            return false;
         }
     }
 

--- a/Server/Player/Runtime/PlayerLifecycleCoordinator.cs
+++ b/Server/Player/Runtime/PlayerLifecycleCoordinator.cs
@@ -11,6 +11,7 @@ using FishNet.Transporting;
 using PlayerScript = ScheduleOne.PlayerScripts.Player;
 #endif
 using DedicatedServerMod.API;
+using DedicatedServerMod.Server.Game.Patches.Gameplay;
 using DedicatedServerMod.Shared.Configuration;
 using DedicatedServerMod.Shared.ModVerification;
 using DedicatedServerMod.Shared.Networking;
@@ -699,6 +700,11 @@ namespace DedicatedServerMod.Server.Player.Runtime
             }
 
             _authentication.HandlePlayerDisconnected(removedPlayer);
+            if (removedPlayer.PlayerInstance != null)
+            {
+                DedicatedPolicePursuitAuthority.ClearPoliceTargeting(removedPlayer.PlayerInstance);
+            }
+
             _publishPlayerLeft(removedPlayer);
 
             try

--- a/Shared/Patches/ActionListStabilityPatches.cs
+++ b/Shared/Patches/ActionListStabilityPatches.cs
@@ -11,11 +11,15 @@ using UnityEngine;
 #if IL2CPP
 using ActionListType = Il2Cpp.ActionList;
 using ActionType = Il2CppSystem.Action;
+using LoadManagerType = Il2CppScheduleOne.Persistence.LoadManager;
 using NativeActionListType = Il2CppSystem.Collections.Generic.List<Il2CppSystem.Action>;
+using SingletonType = Il2CppScheduleOne.DevUtilities.Singleton<Il2CppScheduleOne.Persistence.LoadManager>;
 #else
 using ActionListType = ActionList;
 using ActionType = System.Action;
+using LoadManagerType = ScheduleOne.Persistence.LoadManager;
 using NativeActionListType = System.Collections.Generic.List<System.Action>;
+using SingletonType = ScheduleOne.DevUtilities.Singleton<ScheduleOne.Persistence.LoadManager>;
 #endif
 
 namespace DedicatedServerMod.Shared.Patches
@@ -84,7 +88,24 @@ namespace DedicatedServerMod.Shared.Patches
         private static bool ShouldAbortStaggeredInvocation()
         {
 #if CLIENT
-            return ClientBootstrap.Instance?.ConnectionManager?.IsReturningToMenu == true;
+            var connectionManager = ClientBootstrap.Instance?.ConnectionManager;
+            if (connectionManager?.IsReturningToMenu == true)
+            {
+                return true;
+            }
+
+            try
+            {
+                LoadManagerType loadManager = SingletonType.Instance;
+                return loadManager != null &&
+                       loadManager.IsLoading &&
+                       !loadManager.IsGameLoaded &&
+                       connectionManager?.IsConnecting != true;
+            }
+            catch
+            {
+                return false;
+            }
 #else
             return false;
 #endif

--- a/Shared/Patches/ActionListStabilityPatches.cs
+++ b/Shared/Patches/ActionListStabilityPatches.cs
@@ -11,15 +11,11 @@ using UnityEngine;
 #if IL2CPP
 using ActionListType = Il2Cpp.ActionList;
 using ActionType = Il2CppSystem.Action;
-using LoadManagerType = Il2CppScheduleOne.Persistence.LoadManager;
 using NativeActionListType = Il2CppSystem.Collections.Generic.List<Il2CppSystem.Action>;
-using SingletonType = Il2CppScheduleOne.DevUtilities.Singleton<Il2CppScheduleOne.Persistence.LoadManager>;
 #else
 using ActionListType = ActionList;
 using ActionType = System.Action;
-using LoadManagerType = ScheduleOne.Persistence.LoadManager;
 using NativeActionListType = System.Collections.Generic.List<System.Action>;
-using SingletonType = ScheduleOne.DevUtilities.Singleton<ScheduleOne.Persistence.LoadManager>;
 #endif
 
 namespace DedicatedServerMod.Shared.Patches
@@ -94,18 +90,7 @@ namespace DedicatedServerMod.Shared.Patches
                 return true;
             }
 
-            try
-            {
-                LoadManagerType loadManager = SingletonType.Instance;
-                return loadManager != null &&
-                       loadManager.IsLoading &&
-                       !loadManager.IsGameLoaded &&
-                       connectionManager?.IsConnecting != true;
-            }
-            catch
-            {
-                return false;
-            }
+            return false;
 #else
             return false;
 #endif


### PR DESCRIPTION
## Description

Stabilizes IL2CPP client reconnects after returning to the Menu scene. The first mitigation restored enough client identity for a second join, but repeat joins still exposed stale native/static game state: duplicate GUID registrations, missing variable database entries, packet parse failures, stale client RPC callbacks, and server-side police/NPC pursuit exceptions against disconnected players.

Fixes issue #29.

## Changes Made

- Add an explicit client reconnect cleanup fallback that mirrors the critical native `LoadManager.CleanUp` static resets when IL2CPP reflection cannot safely drive every cleanup side effect.
- Add IL2CPP client guards for stale NPC enter-animation RPCs and shutdown-time `ConfigurationServiceNetworker.OnDestroy` cleanup.
- Clear stale police pursuit/body-search targets when tracked players disconnect, and guard combat/pursuit behaviour updates from dereferencing disconnected player avatars.
- Scope stale NPC behaviour exception suppression to police behaviours whose current target is actually invalid or disconnected.
- Add an opt-in reconnect test runner (`--s1ds-reconnect-test`) that can drive repeated join, dwell, disconnect, and menu-return cycles in the real game.

## Testing Performed

- [x] `dotnet build -c Il2cpp_Client -p:EffectiveConfiguration=Il2cpp_Client -p:TargetFramework=net6.0 -p:AutomateLocalDeployment=false`
- [x] `dotnet build -c Mono_Client -p:EffectiveConfiguration=Mono_Client -p:TargetFramework=netstandard2.1 -p:AutomateLocalDeployment=false`
- [x] `dotnet build -c Il2cpp_Server -p:EffectiveConfiguration=Il2cpp_Server -p:TargetFramework=net6.0 -p:AutomateLocalDeployment=false`
- [x] `dotnet build -c Mono_Server -p:EffectiveConfiguration=Mono_Server -p:TargetFramework=netstandard2.1 -p:AutomateLocalDeployment=false`
- [x] Real-game IL2CPP reconnect harness: 4 total join cycles, 30s dwell per cycle, disconnecting back to Menu between joins.

The final real-game run passed with zero known reconnect spam signatures in the checked log window: FishNet packet parse errors, stale staggered callback errors, missing VariableDatabase entries, duplicate GUID registrations, duplicate message conversations, client `NullReferenceException`, server IL2CPP exceptions, server `NullReferenceException`, and stale police pursuit spam.

## Reviewer Notes

The reconnect runner is disabled unless launched with `--s1ds-reconnect-test`. The cleanup fallback is intentionally scoped to client reconnect/menu transitions and keeps the native cleanup reflection attempt first, then applies the explicit static cleanup resets needed for IL2CPP repeat joins.