### PR TITLE
Clear stale Cpp2IL output before launching the dedicated server

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     unzip \
     xz-utils \
     procps \
+    util-linux \
     xvfb \
     x11-utils \
     && rm -rf /var/lib/apt/lists/*

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     wget \
     unzip \
     xz-utils \
+    procps \
     xvfb \
     x11-utils \
     && rm -rf /var/lib/apt/lists/*

--- a/Docker/README.md
+++ b/Docker/README.md
@@ -157,6 +157,22 @@ docker compose up -d
 
 To build locally from `Docker.zip` instead of pulling from GHCR, replace the `image:` line in the Compose file with the commented `build:` block before running `docker compose up -d --build`.
 
+## IL2CPP Interop Cache Cleanup
+
+After SteamCMD and the pinned MelonLoader bootstrap are applied, and before Wine starts Schedule I, the entrypoint confirms the game is not running and removes only this disposable Cpp2IL output directory:
+
+```text
+/home/steam/game/MelonLoader/Dependencies/Il2CppAssemblyGenerator/Cpp2IL/cpp2il_out
+```
+
+This cleanup is safe and idempotent on every startup. It does not remove `MelonLoader/Il2CppAssemblies`, `Mods`, configuration, saves, or logs. It prevents Il2CppInterop from consuming assemblies that a game update removed but a persistent game volume retained in Cpp2IL output.
+
+### Troubleshooting IL2CPP Interop Generation After A Game Update
+
+If startup reports an Il2CppInterop generation error such as `Pass11ComputeTypeSpecifics`, stop the server, delete only the `cpp2il_out` directory shown above, then start the server so it regenerates the output. The container performs this recovery automatically on every startup.
+
+Do not use a MelonLoader downgrade or reinstall as the primary fix: the inspected `0.7.0` through `0.7.3` releases share the stale-output behavior, and reinstalling often appears to help only because it removes this directory. The image remains pinned to the currently tested MelonLoader `0.7.2` until an upstream release containing [MelonLoader PR #1193](https://github.com/LavaGang/MelonLoader/pull/1193) is tested.
+
 ## Notes
 
 - `STEAM_GUARD` can be supplied when Steam prompts for a guard code.

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -31,6 +31,7 @@ STEAMWORKS_REDIST_DIR=${STEAMWORKS_REDIST_DIR:-"/home/steam/steamworks_redist"}
 FORCE_STEAMCMD_UPDATE=${FORCE_STEAMCMD_UPDATE:-"false"}
 GAME_EXE_PATH="${STEAMAPPDIR}/Schedule I.exe"
 CPP2IL_OUTPUT_DIR="${STEAMAPPDIR}/MelonLoader/Dependencies/Il2CppAssemblyGenerator/Cpp2IL/cpp2il_out"
+GAME_LIFECYCLE_LOCK="${STEAMAPPDIR}/.s1ds-lifecycle.lock"
 
 case "${S1DS_RUNTIME}" in
     mono)
@@ -80,24 +81,54 @@ should_refresh_steamworks_redist() {
     return 1
 }
 
+acquire_game_lifecycle_lock() {
+    mkdir -p "${STEAMAPPDIR}"
+
+    if ! exec 9>"${GAME_LIFECYCLE_LOCK}"; then
+        echo "ERROR: Could not open game lifecycle lock: ${GAME_LIFECYCLE_LOCK}"
+        return 1
+    fi
+
+    if ! flock -n 9; then
+        echo "ERROR: Another dedicated server entrypoint is using ${STEAMAPPDIR}."
+        echo "Stop the other server before updating, cleaning Cpp2IL output, or launching this instance."
+        return 1
+    fi
+
+    echo "Acquired game lifecycle lock: ${GAME_LIFECYCLE_LOCK}"
+}
+
 ensure_game_process_not_running() {
     if pgrep -f '[S]chedule I\.exe' > /dev/null; then
         echo "ERROR: Refusing to clear Cpp2IL output while Schedule I is running."
         pgrep -af '[S]chedule I\.exe' || true
-        exit 1
+        return 1
     fi
 }
 
 clear_stale_cpp2il_output() {
-    ensure_game_process_not_running
+    if ! ensure_game_process_not_running; then
+        return 1
+    fi
 
     if [ -d "${CPP2IL_OUTPUT_DIR}" ]; then
         echo "Removing disposable Cpp2IL output before Wine launch: ${CPP2IL_OUTPUT_DIR}"
-        rm -rf -- "${CPP2IL_OUTPUT_DIR}"
+        if ! rm -rf -- "${CPP2IL_OUTPUT_DIR}"; then
+            echo "ERROR: Failed to remove disposable Cpp2IL output: ${CPP2IL_OUTPUT_DIR}"
+            return 1
+        fi
+    elif [ -e "${CPP2IL_OUTPUT_DIR}" ]; then
+        echo "ERROR: Cpp2IL output path exists but is not a directory: ${CPP2IL_OUTPUT_DIR}"
+        return 1
     else
         echo "Cpp2IL output is already absent; no stale output to remove."
     fi
 }
+
+if ! acquire_game_lifecycle_lock; then
+    kill $XVFB_PID 2>/dev/null || true
+    exit 1
+fi
 
 # Update/install the game via SteamCMD only when needed.
 echo "SteamCMD update mode: FORCE_STEAMCMD_UPDATE=${FORCE_STEAMCMD_UPDATE}"
@@ -200,7 +231,10 @@ fi
 # Cpp2IL output is a disposable cache. A persistent game volume can retain
 # assemblies removed by a game update, which Il2CppInterop then consumes.
 # This runs after game/bootstrap application and before Wine launches.
-clear_stale_cpp2il_output
+if ! clear_stale_cpp2il_output; then
+    kill $XVFB_PID 2>/dev/null || true
+    exit 1
+fi
 
 # Check if the game executable exists
 if [ ! -f "${GAME_EXE_PATH}" ]; then

--- a/Docker/run.sh
+++ b/Docker/run.sh
@@ -30,6 +30,7 @@ STEAM_GUARD=${STEAM_GUARD:-""}
 STEAMWORKS_REDIST_DIR=${STEAMWORKS_REDIST_DIR:-"/home/steam/steamworks_redist"}
 FORCE_STEAMCMD_UPDATE=${FORCE_STEAMCMD_UPDATE:-"false"}
 GAME_EXE_PATH="${STEAMAPPDIR}/Schedule I.exe"
+CPP2IL_OUTPUT_DIR="${STEAMAPPDIR}/MelonLoader/Dependencies/Il2CppAssemblyGenerator/Cpp2IL/cpp2il_out"
 
 case "${S1DS_RUNTIME}" in
     mono)
@@ -77,6 +78,25 @@ should_refresh_steamworks_redist() {
     done
 
     return 1
+}
+
+ensure_game_process_not_running() {
+    if pgrep -f '[S]chedule I\.exe' > /dev/null; then
+        echo "ERROR: Refusing to clear Cpp2IL output while Schedule I is running."
+        pgrep -af '[S]chedule I\.exe' || true
+        exit 1
+    fi
+}
+
+clear_stale_cpp2il_output() {
+    ensure_game_process_not_running
+
+    if [ -d "${CPP2IL_OUTPUT_DIR}" ]; then
+        echo "Removing disposable Cpp2IL output before Wine launch: ${CPP2IL_OUTPUT_DIR}"
+        rm -rf -- "${CPP2IL_OUTPUT_DIR}"
+    else
+        echo "Cpp2IL output is already absent; no stale output to remove."
+    fi
 }
 
 # Update/install the game via SteamCMD only when needed.
@@ -176,6 +196,11 @@ if [ -f "/home/steam/bootstrap/mods/${MOD_DLL_NAME}" ]; then
 else
     echo "WARNING: Missing bootstrap mod DLL: /home/steam/bootstrap/mods/${MOD_DLL_NAME}"
 fi
+
+# Cpp2IL output is a disposable cache. A persistent game volume can retain
+# assemblies removed by a game update, which Il2CppInterop then consumes.
+# This runs after game/bootstrap application and before Wine launches.
+clear_stale_cpp2il_output
 
 # Check if the game executable exists
 if [ ! -f "${GAME_EXE_PATH}" ]; then

--- a/docfx/docs/docker.md
+++ b/docfx/docs/docker.md
@@ -151,6 +151,22 @@ docker compose up -d
 
 To build locally from `Docker.zip` instead of pulling from GHCR, replace the `image:` line in the Compose file with the commented `build:` block before running `docker compose up -d --build`.
 
+## IL2CPP Interop Cache Cleanup
+
+After SteamCMD and the pinned MelonLoader bootstrap are applied, and before Wine starts Schedule I, the entrypoint confirms the game is not running and removes only this disposable Cpp2IL output directory:
+
+```text
+/home/steam/game/MelonLoader/Dependencies/Il2CppAssemblyGenerator/Cpp2IL/cpp2il_out
+```
+
+This cleanup is safe and idempotent on every startup. It does not remove `MelonLoader/Il2CppAssemblies`, `Mods`, configuration, saves, or logs. It prevents Il2CppInterop from consuming assemblies that a game update removed but a persistent game volume retained in Cpp2IL output.
+
+### Troubleshooting IL2CPP Interop Generation After A Game Update
+
+If startup reports an Il2CppInterop generation error such as `Pass11ComputeTypeSpecifics`, stop the server, delete only the `cpp2il_out` directory shown above, then start the server so it regenerates the output. The container performs this recovery automatically on every startup.
+
+Do not use a MelonLoader downgrade or reinstall as the primary fix: the inspected `0.7.0` through `0.7.3` releases share the stale-output behavior, and reinstalling often appears to help only because it removes this directory. The image remains pinned to the currently tested MelonLoader `0.7.2` until an upstream release containing [MelonLoader PR #1193](https://github.com/LavaGang/MelonLoader/pull/1193) is tested.
+
 ## After First Boot
 
 - Edit the generated `server_config.toml` in the mounted game directory

--- a/docfx/docs/hosting-providers.md
+++ b/docfx/docs/hosting-providers.md
@@ -107,6 +107,10 @@ Commercial providers should:
 - make the installed runtime and version visible to customers
 - avoid implying supported-provider, recommended, affiliate, sponsor, official, or exclusive status unless a written arrangement exists
 
+### Game Update Invariant
+
+For every Schedule I update, stop the server before touching its files, then follow this order: update or validate the game, reapply the pinned MelonLoader version, delete only `MelonLoader/Dependencies/Il2CppAssemblyGenerator/Cpp2IL/cpp2il_out`, reapply the DedicatedServerMod release files, then start the server. This prevents stale Cpp2IL output from a prior game build from being passed to Il2CppInterop. Do not use a MelonLoader downgrade as the primary recovery; inspected `0.7.0` through `0.7.3` releases share this behavior, while a reinstall often appears to help only because it removes `cpp2il_out`.
+
 Partnership, affiliate, sponsorship, supported-provider, and recommended-host placements should be disclosed clearly wherever they appear.
 
 ## Related Documentation


### PR DESCRIPTION
## Description

Prevent persistent Docker installs from feeding stale Cpp2IL output into Il2CppInterop after Schedule I updates. The entrypoint now serializes update, cleanup, and launch across containers sharing the game volume and fails closed if the disposable output cannot be removed.

## Related Issues

- Upstream root cause: [LavaGang/MelonLoader#1192](https://github.com/LavaGang/MelonLoader/issues/1192)
- Upstream fix awaiting a tested release: [LavaGang/MelonLoader#1193](https://github.com/LavaGang/MelonLoader/pull/1193)

## Changes Made

- Remove only `MelonLoader/Dependencies/Il2CppAssemblyGenerator/Cpp2IL/cpp2il_out` after update/bootstrap application and before Wine launch.
- Hold a game-volume lifecycle lock across SteamCMD, cleanup, launch, and the server process lifetime.
- Stop startup when Schedule I is already running, cleanup fails, or the output path is not a directory.
- Document automatic cleanup, manual recovery, the MelonLoader `0.7.2` pin, and the commercial-provider update invariant.

## Testing Performed

- [x] `bash -n Docker/run.sh`
- [x] Focused shell harness: cache deletion succeeds, a competing entrypoint cannot acquire the lock, and an undeletable cache fails cleanup
- [x] `dotnet build DedicatedServerMod.csproj -c Documentation -p:AutomateLocalDeployment=false -p:MonoGamePath=...` (0 warnings, 0 errors)
- [x] `docfx docfx/docfx.json` (0 errors; one pre-existing invalid link warning in `docfx/index.md`)
- [x] Docker README/DocFX synchronization assertion
- [x] `git diff --check`
- [ ] Docker image build/runtime smoke: local Docker Desktop daemon is unavailable
- [ ] Containerized ShellCheck: local Docker Desktop daemon is unavailable

## Screenshots

Not applicable; this changes the container entrypoint and documentation without altering a visual interface.

## Checklist

- [x] Code follows [CODING_STANDARDS.md](CODING_STANDARDS.md)
- [x] No public API or XML documentation changes
- [x] No breaking changes
- [x] Updated relevant documentation
- [x] Commit messages follow conventional commit format

## Breaking Changes

None.

## Additional Notes

The image remains pinned to the tested MelonLoader `0.7.2`. Downgrading is not the primary recovery because inspected `0.7.0` through `0.7.3` releases share the stale-output behavior; reinstalling often appears to work because it removes `cpp2il_out`.