### PR TITLE
chore(release): publish DedicatedServerMod 1.0.2

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -56,25 +56,40 @@ jobs:
 
       - name: Check if version needs release
         id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_VERSION: ${{ inputs.version }}
         shell: bash
         run: |
           set -euo pipefail
 
           git fetch --tags
 
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] && [[ -n "${{ inputs.version }}" ]]; then
-            current_version="${{ inputs.version }}"
-            echo "Manual trigger with version: $current_version"
-          else
-            current_version=$(grep -oP 'public const string ModVersion = "\K[^"]+' API/Version.cs | head -n 1)
-            if [[ -z "$current_version" ]]; then
-              echo "Failed to determine version from API/Version.cs" >&2
+          source_version=$(grep -oP 'public const string ModVersion = "\K[^"]+' API/Version.cs | head -n 1)
+          if [[ -z "$source_version" ]]; then
+            echo "Failed to determine version from API/Version.cs" >&2
+            exit 1
+          fi
+
+          if [[ ! "$source_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+            echo "Source version '$source_version' does not match the expected release format" >&2
+            exit 1
+          fi
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]] && [[ -n "$MANUAL_VERSION" ]]; then
+            if [[ "$MANUAL_VERSION" != "$source_version" ]]; then
+              echo "Manual version '$MANUAL_VERSION' does not match API/Version.cs version '$source_version'" >&2
               exit 1
             fi
+
+            current_version="$MANUAL_VERSION"
+            echo "Manual trigger with version: $current_version"
+          else
+            current_version="$source_version"
             echo "Current version from API/Version.cs: $current_version"
           fi
 
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
             echo "Manual trigger requested; publishing or refreshing v$current_version"
             echo "changed=true" >> "$GITHUB_OUTPUT"
           elif git rev-parse "v$current_version" >/dev/null 2>&1; then
@@ -129,12 +144,15 @@ jobs:
 
       - name: Determine Assembly Branch
         id: assembly-branch
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REQUESTED_ASSEMBLY_BRANCH: ${{ inputs.assembly_branch }}
         shell: bash
         run: |
           set -euo pipefail
 
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] && [[ -n "${{ inputs.assembly_branch }}" ]]; then
-            requested_branch="${{ inputs.assembly_branch }}"
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]] && [[ -n "$REQUESTED_ASSEMBLY_BRANCH" ]]; then
+            requested_branch="$REQUESTED_ASSEMBLY_BRANCH"
           else
             requested_branch="master"
           fi
@@ -289,9 +307,11 @@ jobs:
         run: rm -f Directory.Build.targets
 
       - name: Prepare Release Packages
+        env:
+          RELEASE_VERSION: ${{ needs.check-version.outputs.new-version }}
         shell: pwsh
         run: |
-          $version = '${{ needs.check-version.outputs.new-version }}'
+          $version = $env:RELEASE_VERSION
           $releaseRoot = Join-Path $PWD 'release'
           $serverRoot = Join-Path $releaseRoot 'Server'
           $clientRoot = Join-Path $releaseRoot 'Client'
@@ -423,9 +443,11 @@ jobs:
           if-no-files-found: error
 
       - name: Generate Release Notes
+        env:
+          RELEASE_VERSION: ${{ needs.check-version.outputs.new-version }}
         shell: pwsh
         run: |
-          $version = '${{ needs.check-version.outputs.new-version }}'
+          $version = $env:RELEASE_VERSION
           $lastTag = (git for-each-ref refs/tags --sort=-creatordate --format='%(refname:strip=2)' | Select-Object -First 1)
 
           if ($lastTag) {
@@ -473,7 +495,7 @@ jobs:
 
       - name: Upload Mono Server to Nexus Mods
         if: ${{ needs.check-version.outputs.prerelease != 'true' && (github.event_name != 'workflow_dispatch' || inputs.publish_nexus) && env.NEXUSMODS_API_KEY != '' }}
-        uses: Nexus-Mods/upload-action@v1.0.0-beta.10
+        uses: Nexus-Mods/upload-action@c96019556046053aa26044b44396cd38929daf23 # v1.0.0-beta.10
         with:
           api_key: ${{ env.NEXUSMODS_API_KEY }}
           file_id: ${{ env.NEXUSMODS_MONO_SERVER_FILE_GROUP_ID }}
@@ -490,7 +512,7 @@ jobs:
 
       - name: Upload Mono Client to Nexus Mods
         if: ${{ needs.check-version.outputs.prerelease != 'true' && (github.event_name != 'workflow_dispatch' || inputs.publish_nexus) && env.NEXUSMODS_API_KEY != '' }}
-        uses: Nexus-Mods/upload-action@v1.0.0-beta.10
+        uses: Nexus-Mods/upload-action@c96019556046053aa26044b44396cd38929daf23 # v1.0.0-beta.10
         with:
           api_key: ${{ env.NEXUSMODS_API_KEY }}
           file_id: ${{ env.NEXUSMODS_MONO_CLIENT_FILE_GROUP_ID }}
@@ -507,7 +529,7 @@ jobs:
 
       - name: Upload IL2CPP Server to Nexus Mods
         if: ${{ needs.check-version.outputs.prerelease != 'true' && (github.event_name != 'workflow_dispatch' || inputs.publish_nexus) && env.NEXUSMODS_API_KEY != '' }}
-        uses: Nexus-Mods/upload-action@v1.0.0-beta.10
+        uses: Nexus-Mods/upload-action@c96019556046053aa26044b44396cd38929daf23 # v1.0.0-beta.10
         with:
           api_key: ${{ env.NEXUSMODS_API_KEY }}
           file_id: ${{ env.NEXUSMODS_IL2CPP_SERVER_FILE_GROUP_ID }}
@@ -524,7 +546,7 @@ jobs:
 
       - name: Upload IL2CPP Client to Nexus Mods
         if: ${{ needs.check-version.outputs.prerelease != 'true' && (github.event_name != 'workflow_dispatch' || inputs.publish_nexus) && env.NEXUSMODS_API_KEY != '' }}
-        uses: Nexus-Mods/upload-action@v1.0.0-beta.10
+        uses: Nexus-Mods/upload-action@c96019556046053aa26044b44396cd38929daf23 # v1.0.0-beta.10
         with:
           api_key: ${{ env.NEXUSMODS_API_KEY }}
           file_id: ${{ env.NEXUSMODS_IL2CPP_CLIENT_FILE_GROUP_ID }}
@@ -545,12 +567,15 @@ jobs:
         run: echo "::notice::Skipping Nexus Mods uploads because NEXUSMODS_API_KEY is not configured. Rerun this workflow manually after adding the secret."
 
       - name: Summary
+        env:
+          RELEASE_VERSION: ${{ needs.check-version.outputs.new-version }}
+          RELEASE_PRERELEASE: ${{ needs.check-version.outputs.prerelease }}
         shell: pwsh
         run: |
           Add-Content $env:GITHUB_STEP_SUMMARY "### Release Created Successfully"
           Add-Content $env:GITHUB_STEP_SUMMARY ""
-          Add-Content $env:GITHUB_STEP_SUMMARY "**Version:** v${{ needs.check-version.outputs.new-version }}"
-          Add-Content $env:GITHUB_STEP_SUMMARY "**Prerelease:** ${{ needs.check-version.outputs.prerelease }}"
+          Add-Content $env:GITHUB_STEP_SUMMARY "**Version:** v$env:RELEASE_VERSION"
+          Add-Content $env:GITHUB_STEP_SUMMARY "**Prerelease:** $env:RELEASE_PRERELEASE"
           Add-Content $env:GITHUB_STEP_SUMMARY ""
           Add-Content $env:GITHUB_STEP_SUMMARY "**Artifacts:**"
           Add-Content $env:GITHUB_STEP_SUMMARY "- Mono-Server.zip"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -22,6 +22,20 @@ on:
           - main
           - master
           - beta
+      publish_nexus:
+        description: "Upload stable release packages to Nexus Mods"
+        required: false
+        default: true
+        type: boolean
+
+env:
+  NEXUSMODS_API_KEY: ${{ secrets.NEXUSMODS_API_KEY }}
+  NEXUSMODS_MOD_ID: "2169"
+  NEXUSMODS_MONO_SERVER_FILE_GROUP_ID: "7516787"
+  NEXUSMODS_MONO_CLIENT_FILE_GROUP_ID: "7516781"
+  NEXUSMODS_IL2CPP_SERVER_FILE_GROUP_ID: "7516778"
+  NEXUSMODS_IL2CPP_CLIENT_FILE_GROUP_ID: "7516772"
+  RELEASE_DESCRIPTION: Headless dedicated servers for Schedule I with admin commands, save/load support, optional web panel, and client companion support.
 
 jobs:
   check-version:
@@ -60,7 +74,10 @@ jobs:
             echo "Current version from API/Version.cs: $current_version"
           fi
 
-          if git rev-parse "v$current_version" >/dev/null 2>&1; then
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "Manual trigger requested; publishing or refreshing v$current_version"
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          elif git rev-parse "v$current_version" >/dev/null 2>&1; then
             echo "Tag v$current_version already exists, skipping release"
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
@@ -274,6 +291,7 @@ jobs:
       - name: Prepare Release Packages
         shell: pwsh
         run: |
+          $version = '${{ needs.check-version.outputs.new-version }}'
           $releaseRoot = Join-Path $PWD 'release'
           $serverRoot = Join-Path $releaseRoot 'Server'
           $clientRoot = Join-Path $releaseRoot 'Client'
@@ -282,18 +300,72 @@ jobs:
           $dockerRoot = Join-Path $releaseRoot 'Docker'
 
           Remove-Item $releaseRoot -Recurse -Force -ErrorAction SilentlyContinue
-          New-Item -ItemType Directory -Path (Join-Path $serverRoot 'Mods') -Force | Out-Null
-          New-Item -ItemType Directory -Path (Join-Path $clientRoot 'Mods') -Force | Out-Null
-          New-Item -ItemType Directory -Path (Join-Path $il2cppServerRoot 'Mods') -Force | Out-Null
-          New-Item -ItemType Directory -Path (Join-Path $il2cppClientRoot 'Mods') -Force | Out-Null
           New-Item -ItemType Directory -Path $dockerRoot -Force | Out-Null
 
-          Copy-Item 'bin/Mono_Server/netstandard2.1/DedicatedServerMod_Mono_Server.dll' (Join-Path $serverRoot 'Mods/DedicatedServerMod_Mono_Server.dll')
-          Copy-Item 'bin/Mono_Client/netstandard2.1/DedicatedServerMod_Mono_Client.dll' (Join-Path $clientRoot 'Mods/DedicatedServerMod_Mono_Client.dll')
-          Copy-Item 'bin/Il2cpp_Server/net6.0/DedicatedServerMod_Il2cpp_Server.dll' (Join-Path $il2cppServerRoot 'Mods/DedicatedServerMod_Il2cpp_Server.dll')
-          Copy-Item 'bin/Il2cpp_Client/net6.0/DedicatedServerMod_Il2cpp_Client.dll' (Join-Path $il2cppClientRoot 'Mods/DedicatedServerMod_Il2cpp_Client.dll')
-          Copy-Item 'packaging/Server/start_server.bat' (Join-Path $serverRoot 'start_server.bat')
-          Copy-Item 'packaging/Server/start_server.bat' (Join-Path $il2cppServerRoot 'start_server.bat')
+          function Write-PackageTemplate {
+            param(
+              [Parameter(Mandatory)] [string] $Source,
+              [Parameter(Mandatory)] [string] $Destination,
+              [Parameter(Mandatory)] [hashtable] $Tokens
+            )
+
+            $content = [System.IO.File]::ReadAllText((Join-Path $PWD $Source))
+            foreach ($token in $Tokens.GetEnumerator()) {
+              $content = $content.Replace("{{$($token.Key)}}", [string] $token.Value)
+            }
+
+            if ($content -match '\{\{[A-Z_]+\}\}') {
+              throw "Unresolved package template token in $Source"
+            }
+
+            [System.IO.File]::WriteAllText(
+              $Destination,
+              $content,
+              [System.Text.UTF8Encoding]::new($false)
+            )
+          }
+
+          function Initialize-ModPackage {
+            param(
+              [Parameter(Mandatory)] [string] $Root,
+              [Parameter(Mandatory)] [string] $Runtime,
+              [Parameter(Mandatory)] [ValidateSet('Server', 'Client')] [string] $Side,
+              [Parameter(Mandatory)] [string] $DllSource,
+              [Parameter(Mandatory)] [string] $DllName
+            )
+
+            $modsRoot = Join-Path $Root 'Mods'
+            $fomodRoot = Join-Path $Root 'fomod'
+            New-Item -ItemType Directory -Path $modsRoot, $fomodRoot -Force | Out-Null
+
+            Copy-Item $DllSource (Join-Path $modsRoot $DllName)
+            Copy-Item 'marketing/src/assets/logo-icon.png' (Join-Path $Root 'icon.png')
+
+            if ($Side -eq 'Server') {
+              Copy-Item 'packaging/Server/start_server.bat' (Join-Path $Root 'start_server.bat')
+              $serverFile = '                <file source="start_server.bat" destination="" priority="0" />'
+            } else {
+              $serverFile = ''
+            }
+
+            $tokens = @{
+              VERSION = $version
+              RUNTIME = $Runtime
+              SIDE = $Side
+              DLL_NAME = $DllName
+              SERVER_FILE = $serverFile
+            }
+
+            Write-PackageTemplate "packaging/$Side/README.md" (Join-Path $Root 'README.md') $tokens
+            Write-PackageTemplate 'packaging/fomod/info.xml' (Join-Path $fomodRoot 'info.xml') $tokens
+            Write-PackageTemplate 'packaging/fomod/ModuleConfig.xml' (Join-Path $fomodRoot 'ModuleConfig.xml') $tokens
+          }
+
+          Initialize-ModPackage $serverRoot 'Mono' 'Server' 'bin/Mono_Server/netstandard2.1/DedicatedServerMod_Mono_Server.dll' 'DedicatedServerMod_Mono_Server.dll'
+          Initialize-ModPackage $clientRoot 'Mono' 'Client' 'bin/Mono_Client/netstandard2.1/DedicatedServerMod_Mono_Client.dll' 'DedicatedServerMod_Mono_Client.dll'
+          Initialize-ModPackage $il2cppServerRoot 'IL2CPP' 'Server' 'bin/Il2cpp_Server/net6.0/DedicatedServerMod_Il2cpp_Server.dll' 'DedicatedServerMod_Il2cpp_Server.dll'
+          Initialize-ModPackage $il2cppClientRoot 'IL2CPP' 'Client' 'bin/Il2cpp_Client/net6.0/DedicatedServerMod_Il2cpp_Client.dll' 'DedicatedServerMod_Il2cpp_Client.dll'
+
           Copy-Item 'Docker/Dockerfile' (Join-Path $dockerRoot 'Dockerfile')
           Copy-Item 'Docker/docker-compose.example.yml' (Join-Path $dockerRoot 'docker-compose.example.yml')
           Copy-Item 'Docker/run.sh' (Join-Path $dockerRoot 'run.sh')
@@ -315,6 +387,33 @@ jobs:
           Compress-Archive -Path (Join-Path $il2cppServerRoot '*') -DestinationPath (Join-Path $releaseRoot 'Il2cpp_Server.zip') -Force
           Compress-Archive -Path (Join-Path $il2cppClientRoot '*') -DestinationPath (Join-Path $releaseRoot 'Il2cpp_Client.zip') -Force
           Compress-Archive -Path (Get-ChildItem -Path $dockerRoot -Force | ForEach-Object { $_.FullName }) -DestinationPath (Join-Path $releaseRoot 'Docker.zip') -Force
+
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+          function Assert-ZipEntries {
+            param(
+              [Parameter(Mandatory)] [string] $ZipPath,
+              [Parameter(Mandatory)] [string[]] $RequiredEntries
+            )
+
+            $archive = [System.IO.Compression.ZipFile]::OpenRead($ZipPath)
+            try {
+              $entries = @($archive.Entries | ForEach-Object { $_.FullName.Replace('\', '/') })
+              foreach ($entry in $RequiredEntries) {
+                if ($entry -notin $entries) {
+                  throw "Package '$ZipPath' is missing '$entry'"
+                }
+              }
+            } finally {
+              $archive.Dispose()
+            }
+          }
+
+          $commonEntries = @('README.md', 'icon.png', 'fomod/info.xml', 'fomod/ModuleConfig.xml')
+          Assert-ZipEntries (Join-Path $releaseRoot 'Mono-Server.zip') ($commonEntries + @('Mods/DedicatedServerMod_Mono_Server.dll', 'start_server.bat'))
+          Assert-ZipEntries (Join-Path $releaseRoot 'Mono-Client.zip') ($commonEntries + @('Mods/DedicatedServerMod_Mono_Client.dll'))
+          Assert-ZipEntries (Join-Path $releaseRoot 'Il2cpp_Server.zip') ($commonEntries + @('Mods/DedicatedServerMod_Il2cpp_Server.dll', 'start_server.bat'))
+          Assert-ZipEntries (Join-Path $releaseRoot 'Il2cpp_Client.zip') ($commonEntries + @('Mods/DedicatedServerMod_Il2cpp_Client.dll'))
 
       - name: Upload Docker Image Context
         uses: actions/upload-artifact@v4
@@ -371,6 +470,79 @@ jobs:
             release/Il2cpp_Server.zip
             release/Il2cpp_Client.zip
             release/Docker.zip
+
+      - name: Upload Mono Server to Nexus Mods
+        if: ${{ needs.check-version.outputs.prerelease != 'true' && (github.event_name != 'workflow_dispatch' || inputs.publish_nexus) && env.NEXUSMODS_API_KEY != '' }}
+        uses: Nexus-Mods/upload-action@v1.0.0-beta.10
+        with:
+          api_key: ${{ env.NEXUSMODS_API_KEY }}
+          file_id: ${{ env.NEXUSMODS_MONO_SERVER_FILE_GROUP_ID }}
+          mod_id: ${{ env.NEXUSMODS_MOD_ID }}
+          filename: release/Mono-Server.zip
+          version: ${{ needs.check-version.outputs.new-version }}
+          display_name: S1DedicatedServers Server - Mono ${{ needs.check-version.outputs.new-version }}
+          description: ${{ env.RELEASE_DESCRIPTION }}
+          category: main
+          archive_existing_version: true
+          update_mod_version: true
+          allow_mod_manager_download: true
+          show_requirements_pop_up: false
+
+      - name: Upload Mono Client to Nexus Mods
+        if: ${{ needs.check-version.outputs.prerelease != 'true' && (github.event_name != 'workflow_dispatch' || inputs.publish_nexus) && env.NEXUSMODS_API_KEY != '' }}
+        uses: Nexus-Mods/upload-action@v1.0.0-beta.10
+        with:
+          api_key: ${{ env.NEXUSMODS_API_KEY }}
+          file_id: ${{ env.NEXUSMODS_MONO_CLIENT_FILE_GROUP_ID }}
+          mod_id: ${{ env.NEXUSMODS_MOD_ID }}
+          filename: release/Mono-Client.zip
+          version: ${{ needs.check-version.outputs.new-version }}
+          display_name: S1DedicatedServers Client - Mono ${{ needs.check-version.outputs.new-version }}
+          description: ${{ env.RELEASE_DESCRIPTION }}
+          category: main
+          archive_existing_version: true
+          update_mod_version: true
+          allow_mod_manager_download: true
+          show_requirements_pop_up: false
+
+      - name: Upload IL2CPP Server to Nexus Mods
+        if: ${{ needs.check-version.outputs.prerelease != 'true' && (github.event_name != 'workflow_dispatch' || inputs.publish_nexus) && env.NEXUSMODS_API_KEY != '' }}
+        uses: Nexus-Mods/upload-action@v1.0.0-beta.10
+        with:
+          api_key: ${{ env.NEXUSMODS_API_KEY }}
+          file_id: ${{ env.NEXUSMODS_IL2CPP_SERVER_FILE_GROUP_ID }}
+          mod_id: ${{ env.NEXUSMODS_MOD_ID }}
+          filename: release/Il2cpp_Server.zip
+          version: ${{ needs.check-version.outputs.new-version }}
+          display_name: S1DedicatedServers Server - Il2cpp ${{ needs.check-version.outputs.new-version }}
+          description: ${{ env.RELEASE_DESCRIPTION }}
+          category: main
+          archive_existing_version: true
+          update_mod_version: true
+          allow_mod_manager_download: true
+          show_requirements_pop_up: false
+
+      - name: Upload IL2CPP Client to Nexus Mods
+        if: ${{ needs.check-version.outputs.prerelease != 'true' && (github.event_name != 'workflow_dispatch' || inputs.publish_nexus) && env.NEXUSMODS_API_KEY != '' }}
+        uses: Nexus-Mods/upload-action@v1.0.0-beta.10
+        with:
+          api_key: ${{ env.NEXUSMODS_API_KEY }}
+          file_id: ${{ env.NEXUSMODS_IL2CPP_CLIENT_FILE_GROUP_ID }}
+          mod_id: ${{ env.NEXUSMODS_MOD_ID }}
+          filename: release/Il2cpp_Client.zip
+          version: ${{ needs.check-version.outputs.new-version }}
+          display_name: S1DedicatedServers Client - Il2cpp ${{ needs.check-version.outputs.new-version }}
+          description: ${{ env.RELEASE_DESCRIPTION }}
+          category: main
+          archive_existing_version: true
+          update_mod_version: true
+          allow_mod_manager_download: true
+          show_requirements_pop_up: false
+
+      - name: Skip Nexus Mods uploads
+        if: ${{ needs.check-version.outputs.prerelease != 'true' && (github.event_name != 'workflow_dispatch' || inputs.publish_nexus) && env.NEXUSMODS_API_KEY == '' }}
+        shell: bash
+        run: echo "::notice::Skipping Nexus Mods uploads because NEXUSMODS_API_KEY is not configured. Rerun this workflow manually after adding the secret."
 
       - name: Summary
         shell: pwsh

--- a/API/Version.cs
+++ b/API/Version.cs
@@ -15,7 +15,7 @@ namespace DedicatedServerMod.API
         /// <summary>
         /// The mod version following semantic versioning, including a prerelease suffix when applicable.
         /// </summary>
-        public const string ModVersion = "1.0.1";
+        public const string ModVersion = "1.0.2";
 
         /// <summary>
         /// The major version number for breaking change tracking.
@@ -252,7 +252,7 @@ namespace DedicatedServerMod.API
         /// This is human-facing release metadata. The release workflow derives release behavior from
         /// <see cref="ModVersion"/>, not from this date.
         /// </remarks>
-        public const string ReleaseDate = "2026-07-31";
+        public const string ReleaseDate = "2026-08-06";
 
         /// <summary>
         /// The Git commit or tag this version was built from.

--- a/API/Version.cs
+++ b/API/Version.cs
@@ -30,7 +30,7 @@ namespace DedicatedServerMod.API
         /// <summary>
         /// The patch version number for bug fixes.
         /// </summary>
-        public const int PatchVersion = 1;
+        public const int PatchVersion = 2;
 
         /// <summary>
         /// The public API version advertised to addon authors.

--- a/DedicatedServerMod.csproj
+++ b/DedicatedServerMod.csproj
@@ -14,10 +14,10 @@
 		<Configurations>Mono_Client;Mono_Server;Il2cpp_Client;Il2cpp_Server;Documentation</Configurations>
 		<!-- The runtime still owns the obsolete compatibility types; consuming mods continue to receive CS0618. -->
 		<NoWarn>$(NoWarn);0618</NoWarn>
-		<Version>1.0.1</Version>
-		<AssemblyVersion>1.0.1.0</AssemblyVersion>
-		<FileVersion>1.0.1.0</FileVersion>
-		<InformationalVersion>1.0.1</InformationalVersion>
+		<Version>1.0.2</Version>
+		<AssemblyVersion>1.0.2.0</AssemblyVersion>
+		<FileVersion>1.0.2.0</FileVersion>
+		<InformationalVersion>1.0.2</InformationalVersion>
 		<AutomateLocalDeployment Condition="'$(AutomateLocalDeployment)' == '' and '$(CI)' == 'true'">false</AutomateLocalDeployment>
 		<AutomateLocalDeployment Condition="'$(AutomateLocalDeployment)' == '' and '$(CI)' != 'true'">true</AutomateLocalDeployment>
 	</PropertyGroup>

--- a/packaging/Client/README.md
+++ b/packaging/Client/README.md
@@ -1,0 +1,47 @@
+# S1DS - Dedicated Servers
+
+Version: {{VERSION}}<br>
+Runtime: {{RUNTIME}}<br>
+Side: Client
+
+S1DedicatedServers adds a headless server flow for Schedule I, plus the client package players need to connect to dedicated servers. It is built for communities that want a world running 24/7 with admin tools, save/load support, permissions, hosted-console support, and a public API for server/client companion mods.
+
+![S1DedicatedServers documentation](https://raw.githubusercontent.com/ifBars/S1DedicatedServers/master/marketing/src/assets/docs-site.png)
+
+## Core features
+
+- **Dedicated server launch flow:** supports Schedule I dedicated servers.
+- **Client connection support:** lets players join S1DedicatedServers hosts.
+- **Server/client companion mod support:** enables dedicated-server-aware companion mods.
+- **Mono and IL2CPP support:** server and client packages are available for both runtimes.
+- **Public API:** available for addon authors building server/client integrations.
+
+## For players
+
+This package is for {{RUNTIME}} game clients joining {{RUNTIME}} dedicated servers. Most players only need the matching Client package for the runtime used by the server they join.
+
+Do not install a Server package if you only want to join someone else's dedicated server.
+
+## Basic install
+
+1. Install MelonLoader for the {{RUNTIME}} Schedule I runtime.
+2. Extract this archive into the Schedule I install root so the included `Mods` folder merges into the game folder.
+3. Confirm `Mods\{{DLL_NAME}}` exists after extraction.
+4. Launch the game normally and connect to a dedicated server.
+
+## File guide
+
+- **Mono Server:** for a Mono dedicated server install.
+- **Mono Client:** for Mono game clients joining Mono dedicated servers.
+- **IL2CPP Server:** for an IL2CPP dedicated server install.
+- **IL2CPP Client:** for IL2CPP game clients joining IL2CPP dedicated servers.
+
+## Useful links
+
+- [Documentation and quick start](https://docs.s1servers.com/)
+- [Managed server hosting](https://docs.s1servers.com/docs/hosting-providers.html)
+- [GitHub repository](https://github.com/ifBars/S1DedicatedServers)
+- [GitHub releases](https://github.com/ifBars/S1DedicatedServers/releases)
+- [Issues and support](https://github.com/ifBars/S1DedicatedServers/issues)
+
+This mod is not officially affiliated with or endorsed by TVGS or the developers of Schedule I.

--- a/packaging/Server/README.md
+++ b/packaging/Server/README.md
@@ -1,0 +1,52 @@
+# S1DS - Dedicated Servers
+
+Version: {{VERSION}}<br>
+Runtime: {{RUNTIME}}<br>
+Side: Server
+
+S1DedicatedServers adds a headless server flow for Schedule I, plus the client package players need to connect to dedicated servers. It is built for communities that want a world running 24/7 with admin tools, save/load support, permissions, hosted-console support, and a public API for server/client companion mods.
+
+![S1DedicatedServers web panel](https://raw.githubusercontent.com/ifBars/S1DedicatedServers/master/marketing/src/assets/web-panel.png)
+
+## Core features
+
+- **Dedicated server launch flow:** run Schedule I in a server-focused/headless setup.
+- **Save/load support:** keep long-running worlds persistent across server restarts.
+- **Admin tools:** manage players, permissions, moderation, and server commands.
+- **Hosted console support:** works with local terminals and Pterodactyl-style hosting panels.
+- **Optional local web panel:** monitor and operate a local server from a loopback-only panel.
+- **Mono and IL2CPP support:** server and client packages are available for both runtimes.
+- **Docker package:** available from GitHub releases for containerized hosting.
+
+## For server owners
+
+This package is for {{RUNTIME}} server installs. It is meant for communities, test servers, private persistent worlds, and hosted servers.
+
+The server package includes `start_server.bat`. On first boot, the server generates its configuration files in `UserData` so you can tune authentication, ports, saves, permissions, console behavior, and other server details before opening the server to players.
+
+## Basic install
+
+1. Install MelonLoader for the {{RUNTIME}} Schedule I runtime.
+2. Extract this archive into the Schedule I install root so the included `Mods` folder merges into the game folder.
+3. Confirm `Mods\{{DLL_NAME}}` exists after extraction.
+4. Run `start_server.bat` from the game root.
+5. Let the server boot once so it can generate `server_config.toml` and related files.
+6. Edit your save path, authentication settings, permissions, and ports before opening the server publicly.
+
+If you host and play on the same PC, launch the normal Schedule I client before starting the Steam game server.
+
+## Important: pick the right file
+
+- **Server owners:** download a **Server** package for the runtime your server uses.
+- **Players:** download the matching **Client** package for the runtime used by the server they join.
+- **Do not install a Server package** if you only want to join someone else's dedicated server.
+
+## Useful links
+
+- [Documentation and quick start](https://docs.s1servers.com/)
+- [Managed server hosting](https://docs.s1servers.com/docs/hosting-providers.html)
+- [GitHub repository](https://github.com/ifBars/S1DedicatedServers)
+- [GitHub releases](https://github.com/ifBars/S1DedicatedServers/releases)
+- [Issues and support](https://github.com/ifBars/S1DedicatedServers/issues)
+
+This mod is not officially affiliated with or endorsed by TVGS or the developers of Schedule I.

--- a/packaging/fomod/ModuleConfig.xml
+++ b/packaging/fomod/ModuleConfig.xml
@@ -1,0 +1,26 @@
+<!-- Created for S1DedicatedServers release packaging -->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://qconsulting.ca/fo3/ModConfig5.0.xsd">
+  <moduleName>S1DedicatedServers {{RUNTIME}} {{SIDE}}</moduleName>
+  <moduleImage path="icon.png" />
+  <installSteps order="Explicit">
+    <installStep name="Install">
+      <optionalFileGroups order="Explicit">
+        <group name="S1DedicatedServers {{RUNTIME}} {{SIDE}}" type="SelectAll">
+          <plugins order="Explicit">
+            <plugin name="S1DedicatedServers {{RUNTIME}} {{SIDE}}">
+              <description>Install S1DedicatedServers {{RUNTIME}} {{SIDE}}.</description>
+              <image path="icon.png" />
+              <files>
+                <folder source="Mods" destination="Mods" priority="0" />
+{{SERVER_FILE}}
+              </files>
+              <typeDescriptor>
+                <type name="Optional"/>
+              </typeDescriptor>
+            </plugin>
+          </plugins>
+        </group>
+      </optionalFileGroups>
+    </installStep>
+  </installSteps>
+</config>

--- a/packaging/fomod/info.xml
+++ b/packaging/fomod/info.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<fomod>
+  <Name>S1DedicatedServers {{RUNTIME}} {{SIDE}}</Name>
+  <Author>ifBars</Author>
+  <Version>{{VERSION}}</Version>
+  <Website>https://github.com/ifBars/S1DedicatedServers</Website>
+  <Description>Headless dedicated servers for Schedule I with admin commands, save/load support, optional web panel, and client companion support.</Description>
+  <Groups>
+    <element>Utilities</element>
+  </Groups>
+</fomod>


### PR DESCRIPTION
## Summary

- bump DedicatedServerMod and assembly metadata to 1.0.2
- package Mono/IL2CPP client/server archives with the established README, FOMOD, icon, DLL, and server launcher layout
- publish all four stable packages to Nexus Mods mod 2169 using the supplied file group IDs
- allow manual workflow refreshes so Nexus uploads can be retried after a secret or API failure

## Nexus mapping

- Mono Server: 7516787
- Mono Client: 7516781
- IL2CPP Server: 7516778
- IL2CPP Client: 7516772

## Validation

- Mono_Server build: passed, 0 warnings
- Mono_Client build: passed, 0 warnings
- Il2cpp_Server build: passed, 0 warnings
- Il2cpp_Client build: passed, 0 warnings
- workflow YAML parse: passed
- local package generation: passed
- archive entry, version marker, unresolved-token, and assembly-version checks: passed
- git diff --check: passed

## Release requirement

The `NEXUSMODS_API_KEY` repository secret must be present before merge for the automatic Nexus upload. The workflow can be rerun manually for 1.0.2 if the secret is added afterward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Published DedicatedServerMod version `1.0.2`.
- Updated assembly and release metadata.
- Added Mono and IL2CPP client and server packages with the established layout.
- Added FOMOD metadata, package documentation, icons, launchers, and mod contents.
- Added ZIP content validation and unresolved-token checks.
- Added manual Nexus Mods publishing and retry support.
- Published four stable packages to Nexus Mods mod `2169`.
- Requires the `NEXUSMODS_API_KEY` repository secret for automatic uploads.
- All build, workflow, packaging, archive, version, token, and whitespace checks passed.

| Author | Lines added | Lines removed |
|---|---:|---:|
| Not available in the provided summary | — | — |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->