### PR TITLE
fix(server): pause game time when empty

### DIFF
--- a/Server/Game/Patches/Gameplay/TimeManagerPatches.cs
+++ b/Server/Game/Patches/Gameplay/TimeManagerPatches.cs
@@ -1,5 +1,7 @@
 using HarmonyLib;
+using DedicatedServerMod.Server.Core;
 using DedicatedServerMod.Server.Game.Patches.Common;
+using DedicatedServerMod.Shared.Configuration;
 using DedicatedServerMod.Utils;
 #if IL2CPP
 using Il2CppFishNet;
@@ -16,12 +18,30 @@ using UnityEngine;
 
 namespace DedicatedServerMod.Server.Game.Patches.Gameplay
 {
+    internal static class TimeManagerPausePolicy
+    {
+        internal static bool ShouldPauseGame()
+        {
+            if (!InstanceFinder.IsServer ||
+                !Application.isBatchMode ||
+                !ServerConfig.Instance.PauseGameWhenEmpty)
+            {
+                return false;
+            }
+
+            return ServerBootstrap.Players != null && ServerBootstrap.Players.ConnectedPlayerCount == 0;
+        }
+    }
+
     [HarmonyPatch(typeof(TimeManagerType), nameof(TimeManagerType.SetTimeSpeedMultiplier))]
     internal static class TimeManagerSetTimeSpeedMultiplierPatches
     {
         private static void Prefix(ref float multiplier)
         {
-            if (!InstanceFinder.IsServer || !Application.isBatchMode || multiplier > 0f)
+            if (!InstanceFinder.IsServer ||
+                !Application.isBatchMode ||
+                multiplier > 0f ||
+                TimeManagerPausePolicy.ShouldPauseGame())
             {
                 return;
             }
@@ -46,7 +66,12 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
                 return;
             }
 
-            if (__instance.TimeSpeedMultiplier <= 0f)
+            bool shouldPauseGame = TimeManagerPausePolicy.ShouldPauseGame();
+            if (shouldPauseGame && __instance.TimeSpeedMultiplier != 0f)
+            {
+                __instance.SetTimeSpeedMultiplier(0f);
+            }
+            else if (!shouldPauseGame && __instance.TimeSpeedMultiplier <= 0f)
             {
                 __instance.SetTimeSpeedMultiplier(1f);
             }

--- a/Server/Game/Patches/Gameplay/TimeManagerPatches.cs
+++ b/Server/Game/Patches/Gameplay/TimeManagerPatches.cs
@@ -41,7 +41,7 @@ namespace DedicatedServerMod.Server.Game.Patches.Gameplay
             if (!InstanceFinder.IsServer ||
                 !Application.isBatchMode ||
                 multiplier > 0f ||
-                TimeManagerPausePolicy.ShouldPauseGame())
+                (multiplier == 0f && TimeManagerPausePolicy.ShouldPauseGame()))
             {
                 return;
             }


### PR DESCRIPTION
## Description

Makes the existing `gameplay.pauseGameWhenEmpty` option control the authoritative dedicated-server game clock.

The setting was already persisted, documented, and exposed in the web panel, but no runtime time-management path consumed it. The current headless patches also converted every non-positive native time multiplier back to `1`, preventing the base game's supported zero-multiplier pause.

This change:

- pauses the native time multiplier at `0` only when the server is headless, the option is enabled, and no non-loopback players are connected;
- allows that intentional zero multiplier through the existing setter safeguard;
- restores the existing positive-multiplier fallback once the empty-server condition no longer applies;
- preserves the current opt-in default and does not change save or network formats.

Fixes #51

## Validation

- `dotnet build DedicatedServerMod.csproj -c Mono_Server -p:MonoGamePath=... -p:AutomateLocalDeployment=false` — passed, 0 warnings
- `dotnet build DedicatedServerMod.csproj -c Il2cpp_Server -p:Il2CppGamePath=... -p:AutomateLocalDeployment=false` — passed, 0 warnings
- IL2CPP dedicated loaded-save baseline with v1.0.5, `pauseGameWhenEmpty = true`, and only the loopback host: `08:01 -> 08:31` in 30 seconds, multiplier `1`
- Same IL2CPP scenario with this branch: `07:57 -> 07:57` in 30 seconds, multiplier `0`
- IL2CPP compatibility control with this branch and `pauseGameWhenEmpty = false`: `08:01 -> 08:31` in 30 seconds, multiplier `1`

The live test used a disposable log/result probe. The original server config and v1.0.5 DLL were restored, the probe was removed from `Mods`, and no launched game process remains.

## Remaining runtime coverage

- A real-client connect/disconnect cycle was not exercised in this pass. The same update path restores multiplier `1` whenever the non-loopback connected-player count becomes positive and reapplies `0` when it returns to zero.
- Mono runtime behavior was source-inspected and built, but the live smoke was IL2CPP because that is the reported affected build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Pause the authoritative dedicated-server game clock when `gameplay.pauseGameWhenEmpty` is enabled and no non-loopback players are connected.
- Restore the `1f` time multiplier when the server is no longer empty.
- Apply the pause policy to both time-speed multiplier patching and update handling.
- Preserve the opt-in default and existing save and network formats.
- Validate Mono and IL2CPP builds with zero warnings.

| Author | Lines added | Lines removed |
|---|---:|---:|
| Not available | 27 | 2 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->