### PR TITLE
fix(server): stop expired customer message spam

### DIFF
--- a/Server/Game/Patches/UI/HeadlessMessagingPatches.cs
+++ b/Server/Game/Patches/UI/HeadlessMessagingPatches.cs
@@ -2,19 +2,23 @@ using HarmonyLib;
 using DedicatedServerMod.Server.Game.Patches.Common;
 using UnityEngine;
 #if IL2CPP
+using Il2CppScheduleOne.DevUtilities;
 using MessageChainListType = Il2CppSystem.Collections.Generic.List<Il2CppScheduleOne.UI.Phone.Messages.MessageChain>;
 using MessageChainType = Il2CppScheduleOne.UI.Phone.Messages.MessageChain;
 using MessageListType = Il2CppSystem.Collections.Generic.List<Il2CppScheduleOne.Messaging.Message>;
 using MessageType = Il2CppScheduleOne.Messaging.Message;
+using MessagingManagerType = Il2CppScheduleOne.Messaging.MessagingManager;
 using MSGConversationType = Il2CppScheduleOne.Messaging.MSGConversation;
 using ResponseListType = Il2CppSystem.Collections.Generic.List<Il2CppScheduleOne.Messaging.Response>;
 using ResponseType = Il2CppScheduleOne.Messaging.Response;
 #else
 using System.Collections.Generic;
+using ScheduleOne.DevUtilities;
 using MessageChainListType = System.Collections.Generic.List<ScheduleOne.UI.Phone.Messages.MessageChain>;
 using MessageChainType = ScheduleOne.UI.Phone.Messages.MessageChain;
 using MessageListType = System.Collections.Generic.List<ScheduleOne.Messaging.Message>;
 using MessageType = ScheduleOne.Messaging.Message;
+using MessagingManagerType = ScheduleOne.Messaging.MessagingManager;
 using MSGConversationType = ScheduleOne.Messaging.MSGConversation;
 using ResponseListType = System.Collections.Generic.List<ScheduleOne.Messaging.Response>;
 using ResponseType = ScheduleOne.Messaging.Response;
@@ -100,7 +104,10 @@ namespace DedicatedServerMod.Server.Game.Patches.UI
             conversation.onResponsesShown?.Invoke();
         }
 
-        internal static void ClearResponses(MSGConversationType conversation)
+        /// <summary>
+        /// Clears authoritative response state without touching phone UI and optionally relays the clear to clients.
+        /// </summary>
+        internal static void ClearResponses(MSGConversationType conversation, bool network = false)
         {
             if (conversation == null)
             {
@@ -109,6 +116,11 @@ namespace DedicatedServerMod.Server.Game.Patches.UI
 
             conversation.currentResponses.Clear();
             conversation.HasChanged = true;
+
+            if (network)
+            {
+                NetworkSingleton<MessagingManagerType>.Instance.ClearResponses(conversation.sender.ID);
+            }
         }
 
         internal static void ApplyResponseChosen(MSGConversationType conversation, ResponseType response)
@@ -236,12 +248,12 @@ namespace DedicatedServerMod.Server.Game.Patches.UI
     {
         private static bool Prefix(MSGConversationType __instance, bool network)
         {
-            if (!HeadlessMessagingPatchState.ShouldBypassPhoneUi() || network)
+            if (!HeadlessMessagingPatchState.ShouldBypassPhoneUi())
             {
                 return true;
             }
 
-            HeadlessMessagingPatchState.ClearResponses(__instance);
+            HeadlessMessagingPatchState.ClearResponses(__instance, network);
             return false;
         }
     }

--- a/tests/CustomerOfferExpirySmoke/Core.cs
+++ b/tests/CustomerOfferExpirySmoke/Core.cs
@@ -1,0 +1,103 @@
+using System.Reflection;
+using MelonLoader;
+using ScheduleOne.DevUtilities;
+using ScheduleOne.Economy;
+using ScheduleOne.Messaging;
+using ScheduleOne.Persistence;
+using ScheduleOne.Quests;
+using UnityEngine;
+
+[assembly: MelonInfo(typeof(CustomerOfferExpirySmoke.Core), "Customer Offer Expiry Smoke", "1.0.0", "ifBars")]
+[assembly: MelonGame("TVGS", "Schedule I")]
+
+namespace CustomerOfferExpirySmoke
+{
+    internal sealed class Core : MelonMod
+    {
+        private static readonly FieldInfo OfferedContractField = typeof(Customer).GetField(
+            "offeredContractInfo",
+            BindingFlags.Instance | BindingFlags.NonPublic);
+
+        private bool _completed;
+        private float _startedAt;
+
+        public override void OnInitializeMelon()
+        {
+            _startedAt = Time.realtimeSinceStartup;
+            LoggerInstance.Msg("[CUSTOMER_OFFER_EXPIRY_SMOKE] START");
+        }
+
+        public override void OnUpdate()
+        {
+            if (_completed)
+            {
+                return;
+            }
+
+            if (Time.realtimeSinceStartup - _startedAt > 90f)
+            {
+                Complete("FAIL|reason=timeout");
+                return;
+            }
+
+            LoadManager loadManager = Singleton<LoadManager>.Instance;
+            if (loadManager == null || loadManager.IsLoading || !loadManager.IsGameLoaded)
+            {
+                return;
+            }
+
+            Customer customer = Customer.UnlockedCustomers.FirstOrDefault(candidate =>
+                candidate?.NPC?.MSGConversation != null &&
+                candidate.NPC.DialogueHandler?.Database?.HasChain(
+                    ScheduleOne.Dialogue.EDialogueModule.Customer,
+                    "offer_expired") == true);
+            if (customer != null)
+            {
+                RunExpiryRegression(customer);
+            }
+        }
+
+        private void RunExpiryRegression(Customer customer)
+        {
+            if (OfferedContractField == null)
+            {
+                Complete("FAIL|reason=offered-contract-field-missing");
+                return;
+            }
+
+            MSGConversation conversation = customer.NPC.MSGConversation;
+            int chainsBefore = conversation.messageChainHistory.Count;
+            conversation.currentResponses.Add(new Response("Accept", "ACCEPT"));
+            OfferedContractField.SetValue(customer, new ContractInfo());
+
+            int thrownExceptions = 0;
+            for (int i = 0; i < 10; i++)
+            {
+                try
+                {
+                    customer.RpcLogic___ExpireOffer_2166136261();
+                }
+                catch (Exception ex)
+                {
+                    thrownExceptions++;
+                    LoggerInstance.Error($"[CUSTOMER_OFFER_EXPIRY_SMOKE] expiry {i + 1} threw: {ex}");
+                }
+            }
+
+            int addedChains = conversation.messageChainHistory.Count - chainsBefore;
+            bool offerCleared = customer.OfferedContractInfo == null;
+            bool responsesCleared = conversation.currentResponses.Count == 0;
+            bool passed = thrownExceptions == 0 && offerCleared && responsesCleared && addedChains == 1;
+            Complete(
+                $"{(passed ? "PASS" : "FAIL")}|offerCleared={offerCleared}|responsesCleared={responsesCleared}|" +
+                $"expiryExceptions={thrownExceptions}|addedChains={addedChains}");
+        }
+
+        private void Complete(string result)
+        {
+            _completed = true;
+            LoggerInstance.Msg($"[CUSTOMER_OFFER_EXPIRY_SMOKE] {result}");
+            Application.Quit();
+        }
+    }
+}

--- a/tests/CustomerOfferExpirySmoke/Core.cs
+++ b/tests/CustomerOfferExpirySmoke/Core.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using HarmonyLib;
 using MelonLoader;
 using ScheduleOne.DevUtilities;
 using ScheduleOne.Economy;
@@ -14,19 +15,30 @@ namespace CustomerOfferExpirySmoke
 {
     internal sealed class Core : MelonMod
     {
-        private static readonly FieldInfo OfferedContractField = typeof(Customer).GetField(
+        private static readonly FieldInfo _offeredContractField = typeof(Customer).GetField(
             "offeredContractInfo",
             BindingFlags.Instance | BindingFlags.NonPublic);
 
-        private bool _completed;
-        private float _startedAt;
+        private static MSGConversation _targetConversation;
+        private static bool _clientClearReceived;
 
+        private bool _completed;
+        private bool _expiryTriggered;
+        private float _startedAt;
+        private float _expiryTriggeredAt;
+        private Customer _customer;
+        private int _chainsBefore;
+        private int _thrownExceptions;
+
+        /// <inheritdoc />
         public override void OnInitializeMelon()
         {
+            new HarmonyLib.Harmony("DedicatedServerMod.Tests.CustomerOfferExpirySmoke").PatchAll();
             _startedAt = Time.realtimeSinceStartup;
             LoggerInstance.Msg("[CUSTOMER_OFFER_EXPIRY_SMOKE] START");
         }
 
+        /// <inheritdoc />
         public override void OnUpdate()
         {
             if (_completed)
@@ -46,31 +58,51 @@ namespace CustomerOfferExpirySmoke
                 return;
             }
 
-            Customer customer = Customer.UnlockedCustomers.FirstOrDefault(candidate =>
-                candidate?.NPC?.MSGConversation != null &&
-                candidate.NPC.DialogueHandler?.Database?.HasChain(
-                    ScheduleOne.Dialogue.EDialogueModule.Customer,
-                    "offer_expired") == true);
-            if (customer != null)
+            if (!_expiryTriggered)
             {
-                RunExpiryRegression(customer);
+                Customer customer = Customer.UnlockedCustomers.FirstOrDefault(candidate =>
+                    candidate?.NPC?.MSGConversation != null &&
+                    candidate.NPC.DialogueHandler?.Database?.HasChain(
+                        ScheduleOne.Dialogue.EDialogueModule.Customer,
+                        "offer_expired") == true);
+                if (customer != null)
+                {
+                    TriggerExpiryRegression(customer);
+                }
+
+                return;
+            }
+
+            if (_clientClearReceived || Time.realtimeSinceStartup - _expiryTriggeredAt >= 5f)
+            {
+                CompleteExpiryRegression();
             }
         }
 
-        private void RunExpiryRegression(Customer customer)
+        internal static void RecordClientClear(MSGConversation conversation, bool network)
         {
-            if (OfferedContractField == null)
+            if (!network && ReferenceEquals(conversation, _targetConversation))
+            {
+                _clientClearReceived = true;
+            }
+        }
+
+        private void TriggerExpiryRegression(Customer customer)
+        {
+            if (_offeredContractField == null)
             {
                 Complete("FAIL|reason=offered-contract-field-missing");
                 return;
             }
 
+            _customer = customer;
             MSGConversation conversation = customer.NPC.MSGConversation;
-            int chainsBefore = conversation.messageChainHistory.Count;
+            _targetConversation = conversation;
+            _clientClearReceived = false;
+            _chainsBefore = conversation.messageChainHistory.Count;
             conversation.currentResponses.Add(new Response("Accept", "ACCEPT"));
-            OfferedContractField.SetValue(customer, new ContractInfo());
+            _offeredContractField.SetValue(customer, new ContractInfo());
 
-            int thrownExceptions = 0;
             for (int i = 0; i < 10; i++)
             {
                 try
@@ -79,18 +111,26 @@ namespace CustomerOfferExpirySmoke
                 }
                 catch (Exception ex)
                 {
-                    thrownExceptions++;
+                    _thrownExceptions++;
                     LoggerInstance.Error($"[CUSTOMER_OFFER_EXPIRY_SMOKE] expiry {i + 1} threw: {ex}");
                 }
             }
 
-            int addedChains = conversation.messageChainHistory.Count - chainsBefore;
-            bool offerCleared = customer.OfferedContractInfo == null;
-            bool responsesCleared = conversation.currentResponses.Count == 0;
-            bool passed = thrownExceptions == 0 && offerCleared && responsesCleared && addedChains == 1;
+            _expiryTriggered = true;
+            _expiryTriggeredAt = Time.realtimeSinceStartup;
+        }
+
+        private void CompleteExpiryRegression()
+        {
+            int addedChains = _targetConversation.messageChainHistory.Count - _chainsBefore;
+            bool offerCleared = _customer.OfferedContractInfo == null;
+            bool responsesCleared = _targetConversation.currentResponses.Count == 0;
+            bool passed = _thrownExceptions == 0 && offerCleared && responsesCleared &&
+                _clientClearReceived && addedChains == 1;
             Complete(
                 $"{(passed ? "PASS" : "FAIL")}|offerCleared={offerCleared}|responsesCleared={responsesCleared}|" +
-                $"expiryExceptions={thrownExceptions}|addedChains={addedChains}");
+                $"clientClearReceived={_clientClearReceived}|expiryExceptions={_thrownExceptions}|" +
+                $"addedChains={addedChains}");
         }
 
         private void Complete(string result)
@@ -98,6 +138,15 @@ namespace CustomerOfferExpirySmoke
             _completed = true;
             LoggerInstance.Msg($"[CUSTOMER_OFFER_EXPIRY_SMOKE] {result}");
             Application.Quit();
+        }
+    }
+
+    [HarmonyPatch(typeof(MSGConversation), "ClearResponses")]
+    internal static class MSGConversationClearResponsesObserverPatch
+    {
+        private static void Prefix(MSGConversation __instance, bool network)
+        {
+            Core.RecordClientClear(__instance, network);
         }
     }
 }

--- a/tests/CustomerOfferExpirySmoke/CustomerOfferExpirySmoke.csproj
+++ b/tests/CustomerOfferExpirySmoke/CustomerOfferExpirySmoke.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\local.build.props" Condition="Exists('..\..\local.build.props')" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <LangVersion>default</LangVersion>
+    <AssemblyName>CustomerOfferExpirySmoke</AssemblyName>
+    <RootNamespace>CustomerOfferExpirySmoke</RootNamespace>
+    <GamePath Condition="'$(GamePath)' == ''">$(MonoGamePath)</GamePath>
+    <ManagedPath>$(GamePath)\Schedule I_Data\Managed</ManagedPath>
+    <MelonLoaderPath>$(GamePath)\MelonLoader\net35</MelonLoaderPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Reference Include="MelonLoader">
+      <HintPath>$(MelonLoaderPath)\MelonLoader.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>$(ManagedPath)\Assembly-CSharp.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="FishNet.Runtime">
+      <HintPath>$(ManagedPath)\FishNet.Runtime.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>$(ManagedPath)\UnityEngine.CoreModule.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
+  </ItemGroup>
+
+  <Target Name="ValidateGamePath" BeforeTargets="ResolveReferences" Condition="'$(GamePath)' == ''">
+    <Error Text="Set GamePath or MonoGamePath to a Mono Schedule I installation." />
+  </Target>
+</Project>

--- a/tests/CustomerOfferExpirySmoke/CustomerOfferExpirySmoke.csproj
+++ b/tests/CustomerOfferExpirySmoke/CustomerOfferExpirySmoke.csproj
@@ -17,6 +17,10 @@
       <HintPath>$(MelonLoaderPath)\MelonLoader.dll</HintPath>
       <Private>false</Private>
     </Reference>
+    <Reference Include="0Harmony">
+      <HintPath>$(MelonLoaderPath)\0Harmony.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
     <Reference Include="Assembly-CSharp">
       <HintPath>$(ManagedPath)\Assembly-CSharp.dll</HintPath>
       <Private>false</Private>


### PR DESCRIPTION
## Description
Prevents expired customer offers from repeatedly sending "nevermind" messages on headless dedicated servers.

The vanilla networked response-clear path updates phone UI before clearing the pending responses. Dedicated servers do not construct that UI, so the resulting exception left `OfferedContractInfo` active and caused the expiry logic to run again every in-game minute. This change clears authoritative response state without phone UI, then preserves the vanilla clear-response RPC for connected clients.

## Related Issues
Fixes #54

## Changes Made
- Intercept networked `MSGConversation.ClearResponses` calls on headless servers instead of entering client-only phone UI.
- Preserve the vanilla `MessagingManager.ClearResponses` broadcast after clearing server state.
- Add a deterministic real-game smoke mod that injects an expiring customer offer and invokes expiry ten times, asserting exactly one expiry chain and cleared offer/response state.

## Testing Performed
- [x] `dotnet build DedicatedServerMod.csproj -c Mono_Server -p:AutomateLocalDeployment=false`
- [x] `dotnet build DedicatedServerMod.csproj -c Mono_Client -p:AutomateLocalDeployment=false`
- [x] `dotnet build DedicatedServerMod.csproj -c Il2cpp_Server -p:AutomateLocalDeployment=false`
- [x] `dotnet build DedicatedServerMod.csproj -c Il2cpp_Client -p:AutomateLocalDeployment=false`
- [x] `dotnet build tests/CustomerOfferExpirySmoke/CustomerOfferExpirySmoke.csproj -c Release`
- [x] Real Mono dedicated-server smoke on Schedule I Alternate: `PASS|offerCleared=True|responsesCleared=True|clientClearReceived=True|expiryExceptions=0|addedChains=1`

## Screenshots
Not applicable; this is a headless server state/RPC fix.

## Checklist
- [x] Code follows [CODING_STANDARDS.md](CODING_STANDARDS.md)
- [x] XML documentation added where applicable; no public API changed
- [x] No compiler warnings across Mono and IL2CPP server/client builds
- [x] No breaking changes
- [x] Documentation is not affected
- [x] Commit message follows conventional commit format

## Breaking Changes
None.

## Additional Notes
The runtime smoke used an isolated cloned save and restored the original Mods directory and server configuration after completion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Prevents repeated “nevermind” messages after customer offer expiry on headless dedicated servers.
- Clears authoritative response state without invoking client-only phone UI.
- Preserves the vanilla clear-response RPC for connected clients.
- Adds a deterministic smoke test for repeated expiry attempts and state cleanup.
- Validates Mono and IL2CPP server/client builds and dedicated-server expiry behavior.

| Author | Lines added | Lines removed |
|---|---:|---:|
| Not available | 155 | 3 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
