### PR TITLE
fix(client): preserve daily summary stats through sleep

### DIFF
--- a/Client/Core/ClientBootstrap.cs
+++ b/Client/Core/ClientBootstrap.cs
@@ -253,9 +253,9 @@ namespace DedicatedServerMod.Client.Core
         {
             try
             {
-                // Initialize attribute-based patches with logger
-                // MelonLoader will automatically apply patches marked with [HarmonyPatch]
+                // Initialize client-side patch helpers.
                 Patches.SleepPatches.Initialize();
+                Patches.DailySummaryPatches.Initialize();
                 Patches.PolicePatches.Initialize();
                 Patches.GhostHostUiPatches.Initialize();
                 Patches.PauseMenuPatches.Initialize();

--- a/Client/Patches/DailySummaryPatches.cs
+++ b/Client/Patches/DailySummaryPatches.cs
@@ -1,0 +1,156 @@
+using System.Reflection;
+using DedicatedServerMod.Client.Core;
+using DedicatedServerMod.Utils;
+using HarmonyLib;
+#if IL2CPP
+using Il2CppScheduleOne;
+using Il2CppScheduleOne.DevUtilities;
+using Il2CppScheduleOne.UI;
+#else
+using ScheduleOne;
+using ScheduleOne.DevUtilities;
+using ScheduleOne.UI;
+#endif
+
+namespace DedicatedServerMod.Client.Patches
+{
+    /// <summary>
+    /// Preserves daily-summary statistics until dedicated-server clients have consumed them.
+    /// </summary>
+    /// <remarks>
+    /// A headless host completes its side of sleep immediately. The resulting sleep-end event can otherwise clear
+    /// the client accumulators before the daily-summary fade finishes and before the rank summary reads its XP.
+    /// </remarks>
+    internal static class DailySummaryPatches
+    {
+        private static readonly HarmonyLib.Harmony HarmonyInstance = new HarmonyLib.Harmony(
+            "DedicatedServerMod.Client.DailySummaryPatches");
+        private static readonly MethodInfo ClearStatsMethod = AccessTools.Method(typeof(DailySummary), "ClearStats");
+
+        private static bool _initialized;
+        private static bool _summaryConsumed = true;
+        private static bool _statsClearDeferred;
+        private static bool _allowDeferredClear;
+
+        internal static void Initialize()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            MethodInfo sleepStartMethod = AccessTools.Method(typeof(SleepCanvas), "SleepStart");
+            MethodInfo rankUpStartEventMethod = AccessTools.Method(typeof(RankUpCanvas), nameof(RankUpCanvas.StartEvent));
+            MethodInfo dailySummaryCloseMethod = AccessTools.Method(typeof(DailySummary), nameof(DailySummary.Close));
+            if (sleepStartMethod == null || ClearStatsMethod == null || rankUpStartEventMethod == null ||
+                dailySummaryCloseMethod == null)
+            {
+                DebugLog.Warning("Could not initialize dedicated-client daily-summary synchronization patches.");
+                return;
+            }
+
+            HarmonyInstance.Patch(
+                sleepStartMethod,
+                prefix: new HarmonyMethod(typeof(DailySummaryPatches), nameof(SleepStartPrefix)));
+            HarmonyInstance.Patch(
+                ClearStatsMethod,
+                prefix: new HarmonyMethod(typeof(DailySummaryPatches), nameof(ClearStatsPrefix)));
+            HarmonyInstance.Patch(
+                rankUpStartEventMethod,
+                postfix: new HarmonyMethod(typeof(DailySummaryPatches), nameof(RankUpStartEventPostfix)));
+            HarmonyInstance.Patch(
+                dailySummaryCloseMethod,
+                postfix: new HarmonyMethod(typeof(DailySummaryPatches), nameof(DailySummaryClosePostfix)));
+            _initialized = true;
+            DebugLog.StartupDebug("Daily summary synchronization patches initialized");
+        }
+
+        /// <summary>
+        /// Starts a new client summary sequence before the headless host can signal sleep completion.
+        /// </summary>
+        private static void SleepStartPrefix()
+        {
+            if (!IsDedicatedServerSession())
+            {
+                return;
+            }
+
+            _summaryConsumed = false;
+            _statsClearDeferred = false;
+        }
+
+        /// <summary>
+        /// Defers the native sleep-end clear until both daily-summary panels have captured their values.
+        /// </summary>
+        private static bool ClearStatsPrefix()
+        {
+            if (_allowDeferredClear || !IsDedicatedServerSession() || _summaryConsumed)
+            {
+                return true;
+            }
+
+            _statsClearDeferred = true;
+            return false;
+        }
+
+        /// <summary>
+        /// Clears the retained values after the rank summary has synchronously read the daily XP total.
+        /// </summary>
+        private static void RankUpStartEventPostfix()
+        {
+            ConsumeSummaryAndClearStats();
+        }
+
+        /// <summary>
+        /// Handles tutorial sleep sequences, which do not enqueue the rank summary.
+        /// </summary>
+        private static void DailySummaryClosePostfix()
+        {
+            if (GameManager.IS_TUTORIAL)
+            {
+                ConsumeSummaryAndClearStats();
+            }
+        }
+
+        private static bool IsDedicatedServerSession()
+        {
+            return ClientBootstrap.Instance?.ConnectionManager?.IsConnectedToDedicatedServer ?? false;
+        }
+
+        private static void ConsumeSummaryAndClearStats()
+        {
+            if (!IsDedicatedServerSession())
+            {
+                return;
+            }
+
+            _summaryConsumed = true;
+            if (!_statsClearDeferred)
+            {
+                return;
+            }
+
+            DailySummary dailySummary = DailySummary.Instance;
+            if (dailySummary == null || ClearStatsMethod == null)
+            {
+                DebugLog.Warning("Could not complete the deferred daily-summary stats clear.");
+                return;
+            }
+
+            _allowDeferredClear = true;
+            try
+            {
+                ClearStatsMethod.Invoke(dailySummary, null);
+                _statsClearDeferred = false;
+            }
+            catch (Exception ex)
+            {
+                DebugLog.Warning($"Deferred daily-summary stats clear failed: {ex.Message}");
+            }
+            finally
+            {
+                _allowDeferredClear = false;
+            }
+        }
+    }
+}

--- a/Client/Patches/DailySummaryPatches.cs
+++ b/Client/Patches/DailySummaryPatches.cs
@@ -1,3 +1,4 @@
+#if CLIENT
 using System.Reflection;
 using DedicatedServerMod.Client.Core;
 using DedicatedServerMod.Utils;
@@ -6,10 +7,12 @@ using HarmonyLib;
 using Il2CppScheduleOne;
 using Il2CppScheduleOne.DevUtilities;
 using Il2CppScheduleOne.UI;
-#else
+#elif MONO
 using ScheduleOne;
 using ScheduleOne.DevUtilities;
 using ScheduleOne.UI;
+#else
+#error DailySummaryPatches requires either the MONO or IL2CPP runtime symbol.
 #endif
 
 namespace DedicatedServerMod.Client.Patches
@@ -66,7 +69,8 @@ namespace DedicatedServerMod.Client.Patches
         }
 
         /// <summary>
-        /// Starts a new client summary sequence before the headless host can signal sleep completion.
+        /// Patches <see cref="SleepCanvas.SleepStart"/> to begin tracking before the headless host can signal sleep
+        /// completion.
         /// </summary>
         private static void SleepStartPrefix()
         {
@@ -80,7 +84,8 @@ namespace DedicatedServerMod.Client.Patches
         }
 
         /// <summary>
-        /// Defers the native sleep-end clear until both daily-summary panels have captured their values.
+        /// Patches the native <c>DailySummary.ClearStats</c> method to defer its sleep-end clear until both summary
+        /// panels have captured their values.
         /// </summary>
         private static bool ClearStatsPrefix()
         {
@@ -94,7 +99,8 @@ namespace DedicatedServerMod.Client.Patches
         }
 
         /// <summary>
-        /// Clears the retained values after the rank summary has synchronously read the daily XP total.
+        /// Patches <see cref="RankUpCanvas.StartEvent"/> to clear retained values after it synchronously reads the
+        /// daily XP total.
         /// </summary>
         private static void RankUpStartEventPostfix()
         {
@@ -102,7 +108,7 @@ namespace DedicatedServerMod.Client.Patches
         }
 
         /// <summary>
-        /// Handles tutorial sleep sequences, which do not enqueue the rank summary.
+        /// Patches <see cref="DailySummary.Close"/> to clear tutorial summaries, which do not enqueue the rank panel.
         /// </summary>
         private static void DailySummaryClosePostfix()
         {
@@ -154,3 +160,4 @@ namespace DedicatedServerMod.Client.Patches
         }
     }
 }
+#endif


### PR DESCRIPTION
## Summary
- defer the dedicated-client `DailySummary.ClearStats` call when the headless host completes sleep before the client summary opens
- retain earnings, sold items, dealer earnings, and XP until `RankUpCanvas.StartEvent` has synchronously consumed the daily XP value
- keep vanilla host/client sleep behavior unchanged and preserve tutorial cleanup after the first summary closes

## Root cause
The headless server marks `HostSleepDone` immediately. On remote clients, native `TimeManager.WaitForSleepEnd` can therefore invoke `DailySummary.SleepEnd` and clear all daily accumulators during the one-second sleep fade, before `DailySummary.Open` or the rank summary reads them.

## Validation
- reproduced the ordering from the current Mono game methods: `StartSleep` -> immediate `SetHostSleepDone(true)` -> client `SleepEnd`/`ClearStats` before `SleepCanvas.Sleep` reaches `DailySummary.Open`
- exact Mono runtime smoke: seeded native player earnings to 125 and daily XP to 37; confirmed the premature clear was deferred, both values remained available to the summaries, and both cleared to zero after rank-summary consumption
- `dotnet build DedicatedServerMod.csproj -c Mono_Client -p:AutomateLocalDeployment=false`
- `dotnet build DedicatedServerMod.csproj -c Mono_Server -p:AutomateLocalDeployment=false`
- `dotnet build DedicatedServerMod.csproj -c Il2cpp_Client -p:AutomateLocalDeployment=false`
- `dotnet build DedicatedServerMod.csproj -c Il2cpp_Server -p:AutomateLocalDeployment=false`
- `git diff --check`

Fixes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Fixed Daily Summary values clearing before the summary opens on dedicated-server clients.
- Preserved daily earnings, sold items, dealer earnings, XP, and rank-up progress.
- Kept vanilla host/client sleep behavior unchanged.
- Preserved tutorial cleanup after the first summary closes.
- Validated with Mono smoke tests, Mono and IL2CPP builds, and `git diff --check`.

| Author | Lines added | Lines removed |
|---|---:|---:|
| Not available | 158 | 2 |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->