### PR TITLE
fix(client): support native co-op with the client installed

### DIFF
--- a/Client/Core/ClientBootstrap.cs
+++ b/Client/Core/ClientBootstrap.cs
@@ -210,9 +210,6 @@ namespace DedicatedServerMod.Client.Core
                 PermissionSnapshotStore.Initialize();
                 ClientSteamAvatarService.Instance.Initialize();
 
-                // Initialize messaging service (backend selection)
-                Shared.Networking.CustomMessaging.Initialize();
-
                 // Initialize API mod discovery
                 API.ModManager.Initialize();
 

--- a/Client/Managers/ClientAuthManager.cs
+++ b/Client/Managers/ClientAuthManager.cs
@@ -112,6 +112,11 @@ namespace DedicatedServerMod.Client.Managers
         /// </summary>
         internal void Update()
         {
+            if (!ClientConnectionManager.IsDedicatedServerSessionActive)
+            {
+                return;
+            }
+
             TryHookConnectionState();
 
             if (!_isAuthenticated &&
@@ -270,7 +275,10 @@ namespace DedicatedServerMod.Client.Managers
 
         private void OnMessagingEndpointReady()
         {
-            BeginHandshake();
+            if (ClientConnectionManager.IsDedicatedServerSessionActive)
+            {
+                BeginHandshake();
+            }
         }
 
         private bool TryCreateAuthSessionTicket(string serverSteamId, out string steamId, out string ticketHex)

--- a/Client/Managers/ClientConnectionManager.cs
+++ b/Client/Managers/ClientConnectionManager.cs
@@ -191,6 +191,7 @@ namespace DedicatedServerMod.Client.Managers
             LastConnectionError = null;
             long joinAttemptId = ++_activeJoinAttemptId;
 
+            CustomMessaging.Initialize();
             MelonCoroutines.Start(ClientLoadSequence(joinAttemptId));
         }
 
@@ -938,6 +939,7 @@ namespace DedicatedServerMod.Client.Managers
 
             ClientBootstrap.Instance?.AuthManager?.OnDisconnected();
             ClientBootstrap.Instance?.ModVerificationManager?.OnDisconnected();
+            CustomMessaging.Shutdown();
 
             IsConnecting = false;
             IsConnectedToDedicatedServer = false;
@@ -1123,6 +1125,8 @@ namespace DedicatedServerMod.Client.Managers
                 return $"Error getting status: {ex.Message}";
             }
         }
+
+        internal static bool IsDedicatedServerSessionActive => _isTugboatMode;
 
         internal static bool IsTugboatMode => _isTugboatMode;
 

--- a/Client/Managers/ClientConsoleManager.cs
+++ b/Client/Managers/ClientConsoleManager.cs
@@ -169,7 +169,7 @@ namespace DedicatedServerMod.Client.Managers
             try
             {
                 // On dedicated servers, allow console UI for all clients; server will enforce per-command permissions
-                if (InstanceFinder.IsClient && !InstanceFinder.IsHost)
+                if (DedicatedRuntimeContext.IsActive && InstanceFinder.IsClient && !InstanceFinder.IsHost)
                 {
                     __result = AdminStatusManager.CanOpenConsole();
                     return false; // Skip original method
@@ -194,7 +194,7 @@ namespace DedicatedServerMod.Client.Managers
             try
             {
                 // On dedicated servers, allow console UI for all clients and manage UI state here
-                if (InstanceFinder.IsClient && !InstanceFinder.IsHost)
+                if (DedicatedRuntimeContext.IsActive && InstanceFinder.IsClient && !InstanceFinder.IsHost)
                 {
                     if (open && !AdminStatusManager.CanOpenConsole())
                     {
@@ -254,7 +254,7 @@ namespace DedicatedServerMod.Client.Managers
             try
             {
                 // On dedicated servers, route all commands to server for centralized validation and execution
-                if (InstanceFinder.IsClient && !InstanceFinder.IsHost)
+                if (DedicatedRuntimeContext.IsActive && InstanceFinder.IsClient && !InstanceFinder.IsHost)
                 {
                     string commandWord = ExtractCommandWord(args);
                     if (!string.IsNullOrWhiteSpace(commandWord) && !AdminStatusManager.CanUseCommand(commandWord))

--- a/Client/Patchers/ClientLoopbackHandler.cs
+++ b/Client/Patchers/ClientLoopbackHandler.cs
@@ -70,7 +70,7 @@ namespace DedicatedServerMod.Client.Patchers
 
         private void OnPlayerSpawned_CheckLoopback(Player player)
         {
-            if (player == null || InstanceFinder.IsServer)
+            if (!DedicatedRuntimeContext.IsActive || player == null || InstanceFinder.IsServer)
                 return;
 
             try
@@ -106,7 +106,7 @@ namespace DedicatedServerMod.Client.Patchers
         {
             yield return new WaitForSeconds(0.5f);
 
-            if (player == null || player.gameObject == null)
+            if (!DedicatedRuntimeContext.IsActive || player == null || player.gameObject == null)
                 yield break;
 
             try
@@ -139,7 +139,7 @@ namespace DedicatedServerMod.Client.Patchers
 
         internal static void HideLoopbackPresentation(Player player)
         {
-            if (player == null)
+            if (!DedicatedRuntimeContext.IsActive || player == null)
                 return;
 
             DebugLog.Debug($"Hiding ghost host player presentation: {player.PlayerName ?? "Unknown"}");
@@ -156,7 +156,7 @@ namespace DedicatedServerMod.Client.Patchers
         {
             player = null;
 
-            if (poi == null)
+            if (!DedicatedRuntimeContext.IsActive || poi == null)
                 return false;
 
             player = UnityComponentAccess.GetComponentInParent<Player>(poi, includeInactive: true);
@@ -182,7 +182,7 @@ namespace DedicatedServerMod.Client.Patchers
 
             foreach (var player in Player.PlayerList)
             {
-                if (player == null || player.IsGhostHost())
+                if (player == null || (DedicatedRuntimeContext.IsActive && player.IsGhostHost()))
                     continue;
 
                 count++;

--- a/Client/Patchers/ClientTransportPatcher.cs
+++ b/Client/Patchers/ClientTransportPatcher.cs
@@ -95,6 +95,11 @@ namespace DedicatedServerMod.Client.Patchers
             [HarmonyPrefix]
             private static void Prefix(Multipass __instance)
             {
+                if (!DedicatedRuntimeContext.IsActive)
+                {
+                    return;
+                }
+
                 try
                 {
                     var tugboat = __instance.gameObject.GetComponent<Tugboat>();

--- a/Client/Patches/ClientRuntimeStabilityPatches.cs
+++ b/Client/Patches/ClientRuntimeStabilityPatches.cs
@@ -47,6 +47,11 @@ namespace DedicatedServerMod.Client.Patches
 
         private static bool Prefix(TrashItemType __instance)
         {
+            if (!DedicatedRuntimeContext.IsActive)
+            {
+                return true;
+            }
+
             if (__instance == null || __instance.transform == null)
             {
                 return false;
@@ -77,6 +82,11 @@ namespace DedicatedServerMod.Client.Patches
                 return null;
             }
 
+            if (!DedicatedRuntimeContext.IsActive)
+            {
+                return __exception;
+            }
+
             if (__exception is NullReferenceException)
             {
                 DebugLog.Warning("Suppressed stale MSGConversation.RenderMessage after client cleanup.");
@@ -105,6 +115,11 @@ namespace DedicatedServerMod.Client.Patches
 
         private static bool Prefix(NPCEventStayInBuildingType __instance)
         {
+            if (!DedicatedRuntimeContext.IsActive)
+            {
+                return true;
+            }
+
             try
             {
                 if (__instance == null || !CoroutineService.InstanceExists)
@@ -141,7 +156,8 @@ namespace DedicatedServerMod.Client.Patches
     {
         private static bool Prefix(ConfigurationServiceNetworkerType __instance)
         {
-            return __instance != null && __instance.IsServerInitialized;
+            return !DedicatedRuntimeContext.IsActive ||
+                (__instance != null && __instance.IsServerInitialized);
         }
     }
 }

--- a/Client/Patches/GhostHostUiPatches.cs
+++ b/Client/Patches/GhostHostUiPatches.cs
@@ -41,7 +41,7 @@ namespace DedicatedServerMod.Client.Patches
 
         private static bool ShouldFilterGhostHostUi()
         {
-            return InstanceFinder.IsClient && !InstanceFinder.IsServer;
+            return DedicatedRuntimeContext.IsActive && InstanceFinder.IsClient && !InstanceFinder.IsServer;
         }
 
         private static bool ShouldAllowPoiLifecycle(POI poi, string stage)

--- a/Client/Patches/MessagingPatches.cs
+++ b/Client/Patches/MessagingPatches.cs
@@ -61,6 +61,11 @@ namespace DedicatedServerMod.Client.Patches
         {
             private static void Postfix(DailySummary __instance)
             {
+                if (!DedicatedRuntimeContext.IsActive)
+                {
+                    return;
+                }
+
                 try
                 {
                     Shared.Networking.CustomMessaging.DailySummaryAwakePostfix(__instance);

--- a/Client/Patches/PolicePatches.cs
+++ b/Client/Patches/PolicePatches.cs
@@ -70,7 +70,8 @@ namespace DedicatedServerMod.Client.Patches
         {
             try
             {
-                if (!FishNet.InstanceFinder.IsClient
+                if (!DedicatedRuntimeContext.IsActive
+                    || !FishNet.InstanceFinder.IsClient
                     || __instance?.Player == null
                     || !__instance.Player.IsOwner)
                 {
@@ -144,7 +145,8 @@ namespace DedicatedServerMod.Client.Patches
 
         private static bool IsLocalClientCrimeData(PlayerCrimeData crimeData)
         {
-            return FishNet.InstanceFinder.IsClient
+            return DedicatedRuntimeContext.IsActive
+                && FishNet.InstanceFinder.IsClient
                 && crimeData?.Player != null
                 && crimeData.Player.IsOwner;
         }
@@ -209,7 +211,8 @@ namespace DedicatedServerMod.Client.Patches
         {
             Player localPlayer = Player.Local;
             Player targetPlayer = TryGetTargetPlayer(visionEvent);
-            if (!FishNet.InstanceFinder.IsClient
+            if (!DedicatedRuntimeContext.IsActive
+                || !FishNet.InstanceFinder.IsClient
                 || visionCone == null
                 || visionEvent?.Target == null
                 || visionEvent.State == null

--- a/Client/Patches/SavePointPatches.cs
+++ b/Client/Patches/SavePointPatches.cs
@@ -16,7 +16,7 @@ using ScheduleOne.UI;
 namespace DedicatedServerMod.Client.Patches
 {
     /// <summary>
-    /// Holds the loading screen open until dedicated-server authentication completes.
+    /// Suppresses native save-point interaction on dedicated-server clients.
     /// </summary>
     [HarmonyPatch]
     internal static class SavePointPatches
@@ -25,14 +25,14 @@ namespace DedicatedServerMod.Client.Patches
         [HarmonyPrefix]
         private static bool HoveredPrefix()
         {
-            return false;
+            return !DedicatedRuntimeContext.IsActive;
         }
 
         [HarmonyPatch(typeof(InteractableObject), nameof(InteractableObject.Hovered))]
         [HarmonyPrefix]
         private static bool InteractableHoveredPrefix(InteractableObject __instance)
         {
-            return !IsSavePointInteractable(__instance);
+            return !DedicatedRuntimeContext.IsActive || !IsSavePointInteractable(__instance);
         }
 
         private static bool IsSavePointInteractable(InteractableObject interactableObject)

--- a/Client/Patches/SleepPatches.cs
+++ b/Client/Patches/SleepPatches.cs
@@ -58,7 +58,9 @@ namespace DedicatedServerMod.Client.Patches
             [HarmonyPrefix]
             private static bool Prefix(ref bool __result)
             {
-                if (!_ignoreGhostHostForSleep || !FishNet.InstanceFinder.IsClient)
+                if (!DedicatedRuntimeContext.IsActive ||
+                    !_ignoreGhostHostForSleep ||
+                    !FishNet.InstanceFinder.IsClient)
                 {
                     return true;
                 }
@@ -156,6 +158,11 @@ namespace DedicatedServerMod.Client.Patches
 
         private static bool SleepCanvasOpenPrefix()
         {
+            if (!DedicatedRuntimeContext.IsActive)
+            {
+                return true;
+            }
+
             try
             {
                 if (FishNet.InstanceFinder.IsClient && !FishNet.InstanceFinder.IsHost)

--- a/Client/Patches/VehicleHudPatches.cs
+++ b/Client/Patches/VehicleHudPatches.cs
@@ -52,7 +52,10 @@ namespace DedicatedServerMod.Client.Patches
         {
             try
             {
-                if (!InstanceFinder.IsClient || InstanceFinder.IsServer || __instance?.Canvas == null)
+                if (!DedicatedRuntimeContext.IsActive ||
+                    !InstanceFinder.IsClient ||
+                    InstanceFinder.IsServer ||
+                    __instance?.Canvas == null)
                 {
                     return;
                 }

--- a/Shared/Patches/ActionListStabilityPatches.cs
+++ b/Shared/Patches/ActionListStabilityPatches.cs
@@ -29,6 +29,11 @@ namespace DedicatedServerMod.Shared.Patches
     {
         private static bool Prefix(ActionListType __instance, float staggerTime)
         {
+            if (!DedicatedRuntimeContext.IsActive)
+            {
+                return true;
+            }
+
             NativeActionListType invocationList = __instance?.list;
             if (invocationList == null || invocationList.Count == 0)
             {

--- a/Shared/Patches/GuidManagerPatches.cs
+++ b/Shared/Patches/GuidManagerPatches.cs
@@ -31,6 +31,11 @@ internal static class GuidManagerPatches
     [HarmonyPatch("RegisterObject")]
     private static bool RegisterObjectPrefix(GuidRegisterableType obj, GameObject go = null)
     {
+        if (!DedicatedRuntimeContext.IsActive)
+        {
+            return true;
+        }
+
         if (obj == null)
         {
             return false;
@@ -53,6 +58,11 @@ internal static class GuidManagerPatches
     [HarmonyPatch("DeregisterObject")]
     private static bool DeregisterObjectPrefix(GuidRegisterableType obj)
     {
+        if (!DedicatedRuntimeContext.IsActive)
+        {
+            return true;
+        }
+
         if (obj == null)
         {
             return false;
@@ -67,6 +77,11 @@ internal static class GuidManagerPatches
     [HarmonyPatch("GenerateUniqueGUID")]
     private static bool GenerateUniqueGuidPrefix(ref GuidValueType __result)
     {
+        if (!DedicatedRuntimeContext.IsActive)
+        {
+            return true;
+        }
+
         GuidValueType guid;
         do
         {
@@ -82,6 +97,11 @@ internal static class GuidManagerPatches
     [HarmonyPatch("IsGUIDAlreadyRegistered")]
     private static bool IsGuidAlreadyRegisteredPrefix(GuidValueType guid, ref bool __result)
     {
+        if (!DedicatedRuntimeContext.IsActive)
+        {
+            return true;
+        }
+
         __result = GuidManagerType.guidToObject.ContainsKey(guid);
         return false;
     }
@@ -90,6 +110,11 @@ internal static class GuidManagerPatches
     [HarmonyPatch("Clear")]
     private static bool ClearPrefix()
     {
+        if (!DedicatedRuntimeContext.IsActive)
+        {
+            return true;
+        }
+
         GuidManagerType.registeredGUIDs.Clear();
         GuidManagerType.guidToObject.Clear();
         ConsoleType.Log("GUIDManager cleared!");

--- a/Shared/Patches/UnityLoggingPatches.cs
+++ b/Shared/Patches/UnityLoggingPatches.cs
@@ -62,7 +62,7 @@ internal static class UnityLoggingPatches
     [HarmonyPrefix]
     private static bool Prefix(MethodBase __originalMethod, object[] __args)
     {
-        return !ShouldSuppress(__originalMethod, __args);
+        return !DedicatedRuntimeContext.IsActive || !ShouldSuppress(__originalMethod, __args);
     }
 
     private static bool ShouldSuppress(MethodBase originalMethod, object[] args)

--- a/Shared/Patches/WeatherStabilityPatches.cs
+++ b/Shared/Patches/WeatherStabilityPatches.cs
@@ -53,7 +53,7 @@ namespace DedicatedServerMod.Shared.Patches
 #if IL2CPP
         private static void Postfix(WheelType __instance)
         {
-            if (__instance == null || __instance._settings != null)
+            if (!DedicatedRuntimeContext.IsActive || __instance == null || __instance._settings != null)
             {
                 return;
             }
@@ -66,7 +66,7 @@ namespace DedicatedServerMod.Shared.Patches
 #else
         private static void Postfix(ref VehicleSettingsType ____settings, WheelDataType ____defaultData)
         {
-            if (____settings != null)
+            if (!DedicatedRuntimeContext.IsActive || ____settings != null)
             {
                 return;
             }
@@ -107,6 +107,11 @@ namespace DedicatedServerMod.Shared.Patches
             WheelType __instance,
             object newConditions)
         {
+            if (!DedicatedRuntimeContext.IsActive)
+            {
+                return true;
+            }
+
             if (__instance == null)
             {
                 return false;
@@ -164,6 +169,11 @@ namespace DedicatedServerMod.Shared.Patches
             LandVehicleType ___vehicle,
             ref VehicleSettingsType ____settings)
         {
+            if (!DedicatedRuntimeContext.IsActive)
+            {
+                return true;
+            }
+
             VehicleSettingsType resolvedSettings = ____defaultData?.Settings?.Clone()
                 ?? ____settings?.Clone()
                 ?? new VehicleSettingsType();
@@ -219,6 +229,11 @@ namespace DedicatedServerMod.Shared.Patches
         private static bool Prefix(LandVehicleType __instance, WeatherConditionsType newConditions)
 #endif
         {
+            if (!DedicatedRuntimeContext.IsActive)
+            {
+                return true;
+            }
+
             if (__instance?.wheels == null || __instance.wheels.Count == 0)
             {
                 return false;
@@ -260,6 +275,11 @@ namespace DedicatedServerMod.Shared.Patches
 #if IL2CPP
         private static bool Prefix(EnvironmentManagerType __instance)
         {
+            if (!DedicatedRuntimeContext.IsActive)
+            {
+                return true;
+            }
+
             if (__instance == null)
             {
                 return false;
@@ -345,6 +365,11 @@ namespace DedicatedServerMod.Shared.Patches
             float ____neighbourWeatherBlendValue,
             AnimationCurve ____blendCurve)
         {
+            if (!DedicatedRuntimeContext.IsActive)
+            {
+                return true;
+            }
+
             if (____activeWeatherVolumes == null || ____activeWeatherVolumes.Count == 0)
             {
                 return false;

--- a/Utils/DedicatedRuntimeContext.cs
+++ b/Utils/DedicatedRuntimeContext.cs
@@ -1,0 +1,33 @@
+#if CLIENT
+using DedicatedServerMod.Client.Managers;
+#endif
+
+namespace DedicatedServerMod.Utils
+{
+    /// <summary>
+    /// Identifies whether dedicated-server behavior should be active in the current build and session.
+    /// </summary>
+    internal static class DedicatedRuntimeContext
+    {
+        internal static bool IsActive
+        {
+            get
+            {
+#if SERVER
+                return ShouldApply(isServerBuild: true, isDedicatedClientSession: false);
+#elif CLIENT
+                return ShouldApply(
+                    isServerBuild: false,
+                    isDedicatedClientSession: ClientConnectionManager.IsDedicatedServerSessionActive);
+#else
+                return false;
+#endif
+            }
+        }
+
+        internal static bool ShouldApply(bool isServerBuild, bool isDedicatedClientSession)
+        {
+            return isServerBuild || isDedicatedClientSession;
+        }
+    }
+}

--- a/docfx/docs/modding/client.md
+++ b/docfx/docs/modding/client.md
@@ -19,6 +19,8 @@ Client mods implement `IClientMod` or inherit `ClientModBase` / `ClientMelonModB
 
 Use `OnClientPlayerReady()` for logic that depends on UI and messaging already being initialized.
 
+`OnClientInitialize()` runs when the client assembly loads, including during single-player and native co-op. Keep dedicated-only behavior dormant there; activate it from `OnConnectedToServer()` and release session state from `OnDisconnectedFromServer()`.
+
 Prefer the `ModManager` events above for optional client hooks. Keep `IClientMod` and the base classes for coarse lifecycle participation, registration boundaries, and auto-discovery.
 
 ## Client Systems

--- a/docfx/index.md
+++ b/docfx/index.md
@@ -71,6 +71,8 @@ For save path details, see [Save Path](docs/configuration/save-path.md).
 2. Extract `Mono-Client.zip` for Mono or `Il2cpp_Client.zip` for IL2CPP so the included `Mods/` contents merge into that install.
 3. Launch the game normally and connect to the server.
 
+The S1DS client can remain installed for single-player and native co-op. Dedicated transport, messaging, gameplay, and presentation behavior activates only when you start an S1DS dedicated-server connection.
+
 ## After First Boot
 
 - [Overview](docs/index.md)

--- a/tests/DedicatedRuntimeContextTests/DedicatedRuntimeContextTests.csproj
+++ b/tests/DedicatedRuntimeContextTests/DedicatedRuntimeContextTests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\Utils\DedicatedRuntimeContext.cs" Link="DedicatedRuntimeContext.cs" />
+  </ItemGroup>
+</Project>

--- a/tests/DedicatedRuntimeContextTests/Program.cs
+++ b/tests/DedicatedRuntimeContextTests/Program.cs
@@ -1,0 +1,20 @@
+using DedicatedServerMod.Utils;
+
+AssertPolicy(isServerBuild: false, isDedicatedClientSession: false, expected: false);
+AssertPolicy(isServerBuild: false, isDedicatedClientSession: true, expected: true);
+AssertPolicy(isServerBuild: true, isDedicatedClientSession: false, expected: true);
+AssertPolicy(isServerBuild: true, isDedicatedClientSession: true, expected: true);
+
+Console.WriteLine("PASS|DedicatedRuntimeContextTests|cases=4");
+
+static void AssertPolicy(bool isServerBuild, bool isDedicatedClientSession, bool expected)
+{
+    bool actual = DedicatedRuntimeContext.ShouldApply(isServerBuild, isDedicatedClientSession);
+    if (actual != expected)
+    {
+        throw new InvalidOperationException(
+            $"Expected ShouldApply(isServerBuild: {isServerBuild}, " +
+            $"isDedicatedClientSession: {isDedicatedClientSession}) to return {expected}, " +
+            $"but it returned {actual}.");
+    }
+}


### PR DESCRIPTION
## Summary

- keep dedicated-server transport, messaging, gameplay, and presentation patches dormant during native single-player and co-op
- activate client messaging only after an explicit S1DS connection starts and shut it down when returning to the menu
- add a centralized runtime policy with a focused truth-table test
- document the client lifecycle boundary for companion mods

## Root cause

The client assembly initialized dedicated-only services and allowed shared/client Harmony patches to run in every game session. In native co-op that could misclassify the host as the dedicated-server loopback player, alter sleep/save behavior, and execute S1DS stability workarounds against the native host.

## Validation

- `DedicatedRuntimeContextTests`: 4/4 policy cases passed
- `Mono_Client`, `Mono_Server`, `Il2cpp_Client`, and `Il2cpp_Server`: built successfully with zero warnings/errors
- DocFX: completed with zero errors
- Dedicated IL2CPP smoke: join and reconnect passed with no relevant messaging, staggered-action, or null-reference signatures
- Native Mono co-op: two isolated game identities reached `Main`, remained in the same two-member lobby, and exchanged a peer packet
- Native IL2CPP co-op: two isolated game identities reached `Main`, remained in the same two-member lobby, and exchanged a peer packet
- Native co-op logs contained no S1DS messaging initialization, staggered callback errors, relevant S1DS null references, or harness failure markers

The native co-op test validates actual loading and bidirectional peer traffic rather than only waiting in a lobby. A complete bed interaction/sleep cycle was not directly exercised; the dedicated-only sleep patches are covered by the same runtime gate.

Addresses #60. The issue should remain open until affected users have tested the workflow artifacts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Supports native single-player and co-op while the client remains installed.
- Activates dedicated-server transport, messaging, gameplay, and presentation behavior only during an active S1DS session.
- Starts and stops client messaging at dedicated-server connection boundaries.
- Adds `DedicatedRuntimeContext` with truth-table tests.
- Restores native save-point, sleep, weather, vehicle HUD, logging, and other game behavior outside dedicated sessions.
- Documents client lifecycle boundaries for companion mods.
- Validation passed for runtime policy tests, Mono and IL2CPP builds, DocFX, dedicated-server smoke tests, and native co-op scenarios.

| Contributing author | Lines added | Lines removed |
|---|---:|---:|
| Not available in the provided change summary | — | — |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->